### PR TITLE
Added input type to the reported meta data of the benchmarking job

### DIFF
--- a/benchmarking/driver/benchmark_driver.py
+++ b/benchmarking/driver/benchmark_driver.py
@@ -297,6 +297,10 @@ def _retrieveMeta(info, benchmark, platform, framework, backend):
         meta["identifier"] = test["identifier"]
     else:
         meta["identifier"] = meta["net_name"]
+    if 'type' in test['inputs']['data']:
+        meta['input_type'] = test['inputs']['data']['type']
+    else:
+        meta['input_type'] = "None"
 
     # info specific
     if "commit" in info["treatment"]:


### PR DESCRIPTION
Extract the input data type from the benchmarking config and report it to the scuba table as part of the benchmark meta data