### PR TITLE
Add new commandline flag: --user_string

### DIFF
--- a/benchmarking/driver/benchmark_driver.py
+++ b/benchmarking/driver/benchmark_driver.py
@@ -307,4 +307,8 @@ def _retrieveMeta(info, benchmark, platform, framework, backend):
     if "run_type" in info:
         meta["run_type"] = info["run_type"]
 
+    # Local run, user specific information
+    if "user" in info:
+        meta["user"] = info["user"]
+
     return meta

--- a/benchmarking/harness.py
+++ b/benchmarking/harness.py
@@ -104,6 +104,9 @@ getParser().add_argument("--wipe_cache", default=False,
     help="Specify whether to evict cache or not before running")
 getParser().add_argument("--hash_platform_mapping",
     help="Specify the devices hash platform mapping json file.")
+# Avoid the prefix user so that it doesn't collide with --user_identifier
+getParser().add_argument("--user_string",
+    help="Specify the user running the test (to be passed to the remote reporter).")
 
 
 class BenchmarkDriver(object):
@@ -174,6 +177,9 @@ class BenchmarkDriver(object):
                 info["commands"] = {getArgs().framework: {}}
             info["commands"][getArgs().framework]["wipe_cache"] = \
                     getArgs().wipe_cache
+        if getArgs().user_string:
+            info["user"] = getArgs().user_string
+
         return info
 
 


### PR DESCRIPTION
If user_string is provided as the commandline flag, that will be passed as
metadata to the remote reporter. This is intended to be used as:

  ./harness.py ... --user_string $USER