### PR TITLE
Use the command attribute while using {program}

### DIFF
--- a/specifications/models/caffe2/mobilenet_v2/mobilenet_v2_quant.json
+++ b/specifications/models/caffe2/mobilenet_v2/mobilenet_v2_quant.json
@@ -20,7 +20,7 @@
   },
   "tests": [
     {
-      "arguments": "{program} --net {files.predict} --init_net {files.init} --warmup {warmup} --iter {iter} --input \"data\" --input_dims \"1,3,224,224\" --input_type float --run_individual true",
+      "command": "{program} --net {files.predict} --init_net {files.init} --warmup {warmup} --iter {iter} --input \"data\" --input_dims \"1,3,224,224\" --input_type float --run_individual true",
       "identifier": "mobilenet_v2_quant",
       "iter": 50,
       "metric": "delay",

--- a/specifications/models/caffe2/mobilenet_v2/mobilenet_v2_quant_taskset_c.json
+++ b/specifications/models/caffe2/mobilenet_v2/mobilenet_v2_quant_taskset_c.json
@@ -20,7 +20,7 @@
   },
   "tests": [
     {
-      "arguments": "{program} --net {files.predict} --init_net {files.init} --warmup {warmup} --iter {iter} --input \"data\" --input_dims \"1,3,224,224\" --input_type float --run_individual true",
+      "command": "{program} --net {files.predict} --init_net {files.init} --warmup {warmup} --iter {iter} --input \"data\" --input_dims \"1,3,224,224\" --input_type float --run_individual true",
       "identifier": "mobilenet_v2_quant_taskset_c",
       "platform_args": {
         "taskset": "c"

--- a/specifications/models/caffe2/mobilenet_v2/mobilenet_v2_quant_taskset_f0.json
+++ b/specifications/models/caffe2/mobilenet_v2/mobilenet_v2_quant_taskset_f0.json
@@ -20,7 +20,7 @@
   },
   "tests": [
     {
-      "arguments": "{program} --net {files.predict} --init_net {files.init} --warmup {warmup} --iter {iter} --input \"data\" --input_dims \"1,3,224,224\" --input_type float --run_individual true",
+      "command": "{program} --net {files.predict} --init_net {files.init} --warmup {warmup} --iter {iter} --input \"data\" --input_dims \"1,3,224,224\" --input_type float --run_individual true",
       "identifier": "mobilenet_v2_quant_taskset_f0",
       "platform_args": {
         "taskset": "f0"

--- a/specifications/models/tflite/mobilenet_v2/mobilenet_v2_1.0_224_quant.json
+++ b/specifications/models/tflite/mobilenet_v2/mobilenet_v2_1.0_224_quant.json
@@ -15,56 +15,56 @@
   },
   "tests": [
     {
-      "arguments": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=1",
+      "command": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=1",
       "identifier": "mobilenet_v2_1.0_224_quant-1-thread",
       "iter": 50,
       "metric": "delay",
       "warmup": 1
     },
     {
-      "arguments": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=2",
+      "command": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=2",
       "identifier": "mobilenet_v2_1.0_224_quant-2-threads",
       "iter": 50,
       "metric": "delay",
       "warmup": 1
     },
     {
-      "arguments": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=3",
+      "command": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=3",
       "identifier": "mobilenet_v2_1.0_224_quant-3-threads",
       "iter": 50,
       "metric": "delay",
       "warmup": 1
     },
     {
-      "arguments": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=4",
+      "command": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=4",
       "identifier": "mobilenet_v2_1.0_224_quant-4-threads",
       "iter": 50,
       "metric": "delay",
       "warmup": 1
     },
     {
-      "arguments": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=5",
+      "command": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=5",
       "identifier": "mobilenet_v2_1.0_224_quant-5-threads",
       "iter": 50,
       "metric": "delay",
       "warmup": 1
     },
     {
-      "arguments": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=6",
+      "command": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=6",
       "identifier": "mobilenet_v2_1.0_224_quant-6-threads",
       "iter": 50,
       "metric": "delay",
       "warmup": 1
     },
     {
-      "arguments": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=7",
+      "command": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=7",
       "identifier": "mobilenet_v2_1.0_224_quant-7-threads",
       "iter": 50,
       "metric": "delay",
       "warmup": 1
     },
     {
-      "arguments": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=8",
+      "command": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=8",
       "identifier": "mobilenet_v2_1.0_224_quant-8-threads",
       "iter": 50,
       "metric": "delay",

--- a/specifications/models/tflite/mobilenet_v2/mobilenet_v2_1.0_224_quant_taskset_c.json
+++ b/specifications/models/tflite/mobilenet_v2/mobilenet_v2_1.0_224_quant_taskset_c.json
@@ -15,7 +15,7 @@
   },
   "tests": [
     {
-      "arguments": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=1",
+      "command": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=1",
       "identifier": "mobilenet_v2_1.0_224_quant-taskset-c-1-thread",
       "iter": 50,
       "metric": "delay",
@@ -25,7 +25,7 @@
       "warmup": 1
     },
     {
-      "arguments": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=2",
+      "command": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=2",
       "identifier": "mobilenet_v2_1.0_224_quant-taskset-c-2-threads",
       "iter": 50,
       "metric": "delay",
@@ -35,7 +35,7 @@
       "warmup": 1
     },
     {
-      "arguments": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=3",
+      "command": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=3",
       "identifier": "mobilenet_v2_1.0_224_quant-taskset-c-3-threads",
       "iter": 50,
       "metric": "delay",
@@ -45,7 +45,7 @@
       "warmup": 1
     },
     {
-      "arguments": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=4",
+      "command": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=4",
       "identifier": "mobilenet_v2_1.0_224_quant-taskset-c-4-threads",
       "iter": 50,
       "metric": "delay",

--- a/specifications/models/tflite/mobilenet_v2/mobilenet_v2_1.0_224_quant_taskset_f0.json
+++ b/specifications/models/tflite/mobilenet_v2/mobilenet_v2_1.0_224_quant_taskset_f0.json
@@ -15,7 +15,7 @@
   }, 
   "tests": [
     {
-      "arguments": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=1", 
+      "command": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=1", 
       "identifier": "mobilenet_v2_1.0_224_quant-taskset-f0-1-thread", 
       "iter": 50, 
       "metric": "delay", 
@@ -25,7 +25,7 @@
       "warmup": 1
     }, 
     {
-      "arguments": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=2", 
+      "command": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=2", 
       "identifier": "mobilenet_v2_1.0_224_quant-taskset-f0-2-threads", 
       "iter": 50, 
       "metric": "delay", 
@@ -35,7 +35,7 @@
       "warmup": 1
     }, 
     {
-      "arguments": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=3", 
+      "command": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=3", 
       "identifier": "mobilenet_v2_1.0_224_quant-taskset-f0-3-threads", 
       "iter": 50, 
       "metric": "delay", 
@@ -45,7 +45,7 @@
       "warmup": 1
     }, 
     {
-      "arguments": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=4", 
+      "command": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=4", 
       "identifier": "mobilenet_v2_1.0_224_quant-taskset-f0-4-threads", 
       "iter": 50, 
       "metric": "delay", 

--- a/specifications/models/tflite/mobilenet_v2/mobilenet_v2_1.0_224_taskset_f0.json
+++ b/specifications/models/tflite/mobilenet_v2/mobilenet_v2_1.0_224_taskset_f0.json
@@ -15,7 +15,7 @@
   }, 
   "tests": [
     {
-      "arguments": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=1", 
+      "command": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=1", 
       "identifier": "mobilenet_v2_1.0_224-taskset-f0-1-thread", 
       "iter": 50, 
       "metric": "delay", 
@@ -25,7 +25,7 @@
       "warmup": 1
     }, 
     {
-      "arguments": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=2", 
+      "command": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=2", 
       "identifier": "mobilenet_v2_1.0_224-taskset-f0-2-threads", 
       "iter": 50, 
       "metric": "delay", 
@@ -35,7 +35,7 @@
       "warmup": 1
     }, 
     {
-      "arguments": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=3", 
+      "command": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=3", 
       "identifier": "mobilenet_v2_1.0_224-taskset-f0-3-threads", 
       "iter": 50, 
       "metric": "delay", 
@@ -45,7 +45,7 @@
       "warmup": 1
     }, 
     {
-      "arguments": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=4", 
+      "command": "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=4", 
       "identifier": "mobilenet_v2_1.0_224-taskset-f0-4-threads", 
       "iter": 50, 
       "metric": "delay", 


### PR DESCRIPTION
Previously we used {program} in conjunction with "arguments" and this
causes the main program to be repeated twice in the command invocation.
This diff ensures that the program only appears once.

Tested this by running the benchmark files and ensuring the adb shell
command invocations are correct.