### PR TITLE
adding 80 big core config of tflite mobilenetv2 for qnnpack OSS

### DIFF
--- a/specifications/models/tflite/mobilenet_v2/mobilenet_v2_1.0_224_quant_taskset_big_core_80.json
+++ b/specifications/models/tflite/mobilenet_v2/mobilenet_v2_1.0_224_quant_taskset_big_core_80.json
@@ -1,0 +1,30 @@
+{
+  "model": {
+    "category": "CNN",
+    "description": "Trained MobileNet v2 quantized model on TFLite",
+    "files": {
+      "graph": {
+        "filename": "mobilenet_v2_1.0_224_quant.tflite",
+        "location": "https://s3.amazonaws.com/download.caffe2.ai/models/benchmark_models/mobilenet_v2_1.0_224_quant.tflite",
+        "md5": "72bd6012812f0c1ff3c8fbc4101e0981"
+      }
+    },
+    "cooldown": 30,
+    "format": "tflite",
+    "name": "mobilenet_v2_1.0_224_quant"
+  },
+  "tests": [
+    {
+      "commands": [
+        "{program} --graph={files.graph} --warmup_runs={warmup} --num_runs={iter} --input_layer=input --input_layer_shape=\"1,224,224,3\" --num_threads=1"
+      ],
+      "identifier": "mobilenet_v2_1.0_224_quant-1-thread",
+      "iter": 50,
+      "metric": "delay",
+      "platform_args": {
+        "taskset": "80"
+      },
+      "warmup": 1
+    }
+  ]
+}


### PR DESCRIPTION
adding 80 big core config of tflite mobilenetv2 for qnnpack OSS

To make sure TFLite number makes sense, I tried to reproduce the experiment setup in their website(https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/lite/g3doc/models.md) using our PEP. They use single thread TFLite on Big Core of Pixel 2. They report 117ms for latency. Our PEP shows on big core of my Pixel-2-P-27 phone, with single Big Core(I use the fifth one, taskset=“80”), we are seeing 81ms inference latency.