### PR TITLE
 Each unique test get a separate copy of the framework

### DIFF
--- a/benchmarking/harness.py
+++ b/benchmarking/harness.py
@@ -134,13 +134,14 @@ class BenchmarkDriver(object):
     def runBenchmark(self, info, platform, benchmarks):
         if getArgs().reboot:
             platform.rebootDevice()
-        tempdir = tempfile.mkdtemp()
-        # we need to get a different framework instance per thread
-        # will consolidate later. For now create a new framework
-        frameworks = getFrameworks()
-        framework = frameworks[getArgs().framework](tempdir)
-        reporters = getReporters()
         for idx in range(len(benchmarks)):
+            tempdir = tempfile.mkdtemp()
+            # we need to get a different framework instance per thread
+            # will consolidate later. For now create a new framework
+            frameworks = getFrameworks()
+            framework = frameworks[getArgs().framework](tempdir)
+            reporters = getReporters()
+
             benchmark = benchmarks[idx]
             # check the framework matches
             if "model" in benchmark and "framework" in benchmark["model"]:

--- a/benchmarking/harness.py
+++ b/benchmarking/harness.py
@@ -173,7 +173,7 @@ class BenchmarkDriver(object):
                 if "model" in benchmark and "cooldown" in benchmark["model"]:
                     cooldown = float(benchmark["model"]["cooldown"])
                 time.sleep(cooldown)
-        shutil.rmtree(tempdir, True)
+            shutil.rmtree(tempdir, True)
 
     def run(self):
         tempdir = tempfile.mkdtemp()


### PR DESCRIPTION
We move the framework generate to inside the loop. This way each test has a separate copy of temporary directory so they do not overlap. 

We may later extract out the entire benchmark driver to a separate python binary, and do not catch the exception and let it fail. We need that to give better error messages. 