### PR TITLE
If any of the command fail, propagate the failure to the top instead …

### DIFF
--- a/benchmarking/driver/benchmark_driver.py
+++ b/benchmarking/driver/benchmark_driver.py
@@ -14,7 +14,7 @@ import sys
 import time
 from utils.arg_parse import getArgs
 from utils.custom_logger import getLogger
-from utils.utilities import getCommand, deepMerge
+from utils.utilities import getCommand, deepMerge, setRunFailure
 
 
 def runOneBenchmark(info, benchmark, framework, platform,
@@ -55,6 +55,7 @@ def runOneBenchmark(info, benchmark, framework, platform,
             "Exception caught when running benchmark")
         getLogger().info(e)
         data = None
+        setRunFailure()
 
     if data is None or len(data) == 0:
         name = platform.getMangledName()

--- a/benchmarking/harness.py
+++ b/benchmarking/harness.py
@@ -24,7 +24,7 @@ from platforms.platforms import getPlatforms
 from reporters.reporters import getReporters
 from utils.arg_parse import getParser, getArgs, parseKnown
 from utils.custom_logger import getLogger
-from utils.utilities import parse_kwarg
+from utils.utilities import parse_kwarg, isRunSuccess
 
 # for backward compatible purpose
 getParser().add_argument("--backend",
@@ -223,6 +223,6 @@ class BenchmarkDriver(object):
 if __name__ == "__main__":
     app = BenchmarkDriver()
     app.run()
-    getLogger().info(" ======= Run {}".format("success" if app.success else "failure"))
-    if not app.success:
-        sys.exit(1)
+    getLogger().info(" ======= Run {}".format(
+        "success" if app.success and isRunSuccess() else "failure"))
+    sys.exit(0 if app.success else 1)

--- a/benchmarking/run_bench.py
+++ b/benchmarking/run_bench.py
@@ -12,6 +12,7 @@ import copy
 import json
 import os
 import six
+import sys
 from utils.arg_parse import getParser, getArgs, getUnknowns, parseKnown
 from utils.custom_logger import getLogger
 from utils.utilities import getPythonInterpreter, getString
@@ -24,12 +25,13 @@ class RunBench(object):
     def __init__(self):
         self.home_dir = os.path.expanduser('~')
         self.root_dir = os.path.join(self.home_dir, ".aibench", "git")
+        self.ret = 0
         parseKnown()
 
     def run(self):
         cmd = self._getCMD()
         getLogger().info("Running: %s", cmd)
-        os.system(cmd)
+        self.ret = os.system(cmd)
 
     def _getUnknownArgs(self):
         unknowns = getUnknowns()
@@ -144,3 +146,4 @@ class RunBench(object):
 if __name__ == "__main__":
     app = RunBench()
     app.run()
+    sys.exit(app.ret)

--- a/benchmarking/utils/subprocess_with_logger.py
+++ b/benchmarking/utils/subprocess_with_logger.py
@@ -15,6 +15,7 @@ from __future__ import unicode_literals
 import subprocess
 import sys
 from .custom_logger import getLogger
+from .utilities import setRunFailure
 
 
 def processRun(*args, **kwargs):
@@ -39,4 +40,5 @@ def processRun(*args, **kwargs):
         getLogger().error("Unknown exception {}: {}".format(sys.exc_info()[0],
                                                             ' '.join(*args)))
         err_output = "{}".format(sys.exc_info()[0])
+    setRunFailure()
     return None, err_output

--- a/benchmarking/utils/utilities.py
+++ b/benchmarking/utils/utilities.py
@@ -149,3 +149,15 @@ def parse_kwarg(kwarg_str):
     except ValueError:
         getLogger().error("Failed to parse kwarg str: {}".format(kwarg_str))
     return key, value
+
+
+run_success = True
+
+
+def isRunSuccess():
+    return run_success
+
+
+def setRunFailure():
+    global run_success
+    run_success = False


### PR DESCRIPTION
…of silently ignoring it.

In the longer run, we need to extract the single thread run to a separate program and wrap around with the thread management. For now, we just bubble up the error status.  