### PR TITLE
Separate out the user error from the harness error. If a subprocess r…

### DIFF
--- a/benchmarking/platforms/ios/ios_platform.py
+++ b/benchmarking/platforms/ios/ios_platform.py
@@ -17,7 +17,7 @@ from platforms.platform_base import PlatformBase
 from utils.arg_parse import getParser, getArgs
 from utils.custom_logger import getLogger
 from utils.subprocess_with_logger import processRun
-from utils.utilities import isRunSuccess, setRunStatus
+from utils.utilities import getRunStatus, setRunStatus
 
 getParser().add_argument("--ios_dir", default="/tmp",
     help="The directory in the ios device all files are pushed to.")
@@ -57,11 +57,12 @@ class IOSPlatform(PlatformBase):
         bundle_id, _ = processRun(["osascript", "-e",
                                    "id of app \"" + self.app + "\""])
 
+        assert bundle_id, "bundle id cannot be found"
         self.util.setBundleId(bundle_id.strip())
 
         # We know this command will fail. Avoid propogating this
         # failure to the upstream
-        success = isRunSuccess()
+        success = getRunStatus()
         self.util.run(["--bundle", self.app,
                       "--uninstall", "--noninteractive"])
         setRunStatus(success)

--- a/benchmarking/utils/build_program.py
+++ b/benchmarking/utils/build_program.py
@@ -23,12 +23,12 @@ def buildProgramPlatform(dst, repo_dir, framework, frameworks_dir, platform):
     os.makedirs(dst_dir)
 
     if os.name == "nt":
-        result = processRun([script, repo_dir, dst])[0]
+        result, _ = processRun([script, repo_dir, dst])
     else:
-        result = processRun(['sh', script, repo_dir, dst])[0]
-    if result is not None:
+        result, _ = processRun(['sh', script, repo_dir, dst])
+    if os.path.isfile(dst):
         os.chmod(dst, 0o777)
-    print(result)
+    getLogger().info(result)
 
     if not os.path.isfile(dst) and \
             (not (os.path.isdir(dst) and platform.startswith("ios"))):

--- a/benchmarking/utils/subprocess_with_logger.py
+++ b/benchmarking/utils/subprocess_with_logger.py
@@ -46,5 +46,5 @@ def processRun(*args, **kwargs):
         getLogger().error("Unknown exception {}: {}".format(sys.exc_info()[0],
                                                             ' '.join(*args)))
         err_output = "{}".format(sys.exc_info()[0])
-    setRunStatus(False)
-    return None, err_output
+    setRunStatus(1)
+    return "", err_output

--- a/benchmarking/utils/utilities.py
+++ b/benchmarking/utils/utilities.py
@@ -151,13 +151,17 @@ def parse_kwarg(kwarg_str):
     return key, value
 
 
-run_success = True
+# run_status == 0: success
+# run_status == 1: user error
+# run_status == 2: harness error
+# run_status == 3: both user and harness error
+run_status = 0
 
 
-def isRunSuccess():
-    return run_success
+def getRunStatus():
+    return run_status
 
 
 def setRunStatus(status):
-    global run_success
-    run_success = status
+    global run_status
+    run_status = run_status | status


### PR DESCRIPTION
…un failed, return "" for the log instead of returning None. This prevents user error turning into harness error