### PR TITLE
Add timeout feature to python 2.7

### DIFF
--- a/benchmarking/driver/benchmark_driver.py
+++ b/benchmarking/driver/benchmark_driver.py
@@ -97,6 +97,9 @@ def _runOnePass(info, benchmark, framework, platform):
         one_output, output_files = \
             framework.runBenchmark(info, benchmark, platform)
         deepMerge(output, one_output)
+        if getRunStatus() != 0:
+            # early exit if there is an error
+            break
     data = _processDelayData(output)
     return data
 

--- a/benchmarking/frameworks/tflite/tflite.py
+++ b/benchmarking/frameworks/tflite/tflite.py
@@ -10,6 +10,7 @@
 
 import os
 import re
+from six import string_types
 
 from frameworks.framework_base import FrameworkBase
 
@@ -88,7 +89,8 @@ class TFLiteFramework(FrameworkBase):
         if output is None:
             return False
         results = {}
-        rows = output.split('\n')
+        if isinstance(output, string_types):
+            rows = output.split('\n')
         # only collect one data point for statistics
         # the actual run data should override the warmup data
         i = 0

--- a/benchmarking/harness.py
+++ b/benchmarking/harness.py
@@ -110,8 +110,7 @@ getParser().add_argument("--string_map",
 getParser().add_argument("--timeout", default=300, type=float,
     help="Specify a timeout running the test on the platforms. "
     "The timeout value needs to be large enough so that the low end devices "
-    "can safely finish the execution in normal conditions. Note, in A/B "
-    "testing mode, the test runs twice. ")
+    "can safely finish the execution in normal conditions. ")
 getParser().add_argument("--user_identifier",
     help="User can specify an identifier and that will be passed to the "
     "output so that the result can be easily identified.")

--- a/benchmarking/platforms/android/adb.py
+++ b/benchmarking/platforms/android/adb.py
@@ -23,10 +23,6 @@ class ADB(PlatformUtilBase):
         adb = self._addADB()
         return super(ADB, self).run(adb, *args, **kwargs)
 
-    def runAsync(self, *args, **kwargs):
-        adb = self._addADB()
-        return super(ADB, self).runAsync(adb, *args, **kwargs)
-
     def push(self, src, tgt):
         # Always remove the old file before pushing the new file
         self.deleteFile(tgt)

--- a/benchmarking/platforms/android/android_driver.py
+++ b/benchmarking/platforms/android/android_driver.py
@@ -26,8 +26,7 @@ class AndroidDriver:
 
     def getDevices(self):
         adb = ADB()
-        devices_str = adb.run("devices", "-l")
-        rows = devices_str.split('\n')
+        rows = adb.run("devices", "-l")
         rows.pop(0)
         devices = set()
         for row in rows:

--- a/benchmarking/platforms/host/host_platform.py
+++ b/benchmarking/platforms/host/host_platform.py
@@ -44,21 +44,17 @@ class HostPlatform(PlatformBase):
     def runBenchmark(self, cmd, *args, **kwargs):
         if not isinstance(cmd, list):
             cmd = shlex.split(cmd)
-        host_kwargs = {}
+        platform_args = {}
         env = os.environ
         if "platform_args" in kwargs:
             platform_args = kwargs["platform_args"]
-            if "timeout" in platform_args:
-                host_kwargs["timeout"] = platform_args["timeout"]
-            # used for local or remote log control
-            host_kwargs["log_output"] = platform_args.get("log_output", False)
             if "env" in platform_args:
                 customized_env = platform_args["env"]
                 for k in customized_env:
                     env[k] = str(customized_env[k])
-                host_kwargs["env"] = env
+                platform_args["env"] = env
 
-        output, _ = processRun(cmd, **host_kwargs)
+        output, _ = processRun(cmd, **platform_args)
         return output
 
     def _getProcessorName(self):
@@ -67,12 +63,12 @@ class HostPlatform(PlatformBase):
         elif platform.system() == "Darwin":
             processor_info, _ = processRun(
                 ["sysctl", "-n", "machdep.cpu.brand_string"])
-            if processor_info:
-                return processor_info.rstrip()
+            if len(processor_info) > 0:
+                return processor_info[0].rstrip()
         elif platform.system() == "Linux":
             processor_info, _ = processRun(["cat", "/proc/cpuinfo"])
             if processor_info:
-                for line in processor_info.split("\n"):
+                for line in processor_info:
                     if "model name" in line:
                         return re.sub(".*model name.*:", "", line, 1)
         return ""

--- a/benchmarking/platforms/ios/ios_driver.py
+++ b/benchmarking/platforms/ios/ios_driver.py
@@ -27,10 +27,9 @@ class IOSDriver(object):
 
     def getDevices(self):
         idb = IDB()
-        devices_str = idb.run("--detect")
-        if devices_str is None:
+        rows = idb.run("--detect")
+        if len(rows) == 0:
             return {}
-        rows = devices_str.split('\n')
         rows.pop(0)
         pattern = re.compile(".* Found ([\d|a-f]+) \((\w+), .+\) a\.k\.a\. .*")
         devices = {}

--- a/benchmarking/platforms/ios/ios_platform.py
+++ b/benchmarking/platforms/ios/ios_platform.py
@@ -30,9 +30,6 @@ class IOSPlatform(PlatformBase):
         self.type = "ios"
         self.app = None
 
-    def runCommand(self, cmd):
-        return self.util.run(cmd)
-
     def preprocess(self, *args, **kwargs):
         assert "programs" in kwargs, "Must have programs specified"
 
@@ -56,9 +53,8 @@ class IOSPlatform(PlatformBase):
 
         bundle_id, _ = processRun(["osascript", "-e",
                                    "id of app \"" + self.app + "\""])
-
-        assert bundle_id, "bundle id cannot be found"
-        self.util.setBundleId(bundle_id.strip())
+        assert len(bundle_id) > 0, "bundle id cannot be found"
+        self.util.setBundleId(bundle_id[0].strip())
 
         # We know this command will fail. Avoid propogating this
         # failure to the upstream
@@ -79,17 +75,13 @@ class IOSPlatform(PlatformBase):
         tgt_argument_filename = os.path.join(self.tgt_dir, "benchmark.json")
         self.util.push(argument_filename, tgt_argument_filename)
 
-        ios_kwargs = {}
+        platform_args = {}
         if "platform_args" in kwargs:
             platform_args = kwargs["platform_args"]
-            if "timeout" in platform_args and platform_args["timeout"]:
-                ios_kwargs["timeout"] = platform_args["timeout"]
-                del platform_args["timeout"]
-            ios_kwargs["log_output"] = platform_args.get("log_output", False)
 
         run_cmd = ["--bundle", self.app, "--noninteractive", "--noinstall"]
         # the command may fail, but the err_output is what we need
-        log_screen = self.util.run(run_cmd, **ios_kwargs)
+        log_screen = self.util.run(run_cmd, **platform_args)
         return log_screen
 
     def rebootDevice(self):

--- a/benchmarking/platforms/platform_base.py
+++ b/benchmarking/platforms/platform_base.py
@@ -64,10 +64,6 @@ class PlatformBase(object):
         pass
 
     @abc.abstractmethod
-    def runCommand(self, cmd):
-        pass
-
-    @abc.abstractmethod
     def runBenchmark(self, cmd, *args, **kwargs):
         return None
 

--- a/benchmarking/platforms/platform_util_base.py
+++ b/benchmarking/platforms/platform_util_base.py
@@ -10,7 +10,7 @@
 
 import abc
 
-from utils.subprocess_with_logger import processRun, Popen
+from utils.subprocess_with_logger import processRun
 
 
 class PlatformUtilBase(object):
@@ -21,10 +21,6 @@ class PlatformUtilBase(object):
     def run(self, *args, **kwargs):
         cmd = self._prepareCMD(*args)
         return processRun(cmd, **kwargs)[0]
-
-    def runAsync(self, *args, **kwargs):
-        cmd = self._prepareCMD(*args)
-        return Popen(cmd)
 
     @abc.abstractmethod
     def push(self, src, tgt):

--- a/benchmarking/repos/git.py
+++ b/benchmarking/repos/git.py
@@ -23,7 +23,7 @@ class GitRepo(RepoBase):
             git.append(self.dir)
         git.append(cmd)
         git.extend(args)
-        return processRun(git)[0]
+        return '\n'.join(processRun(git)[0])
 
     def pull(self, *args):
         return self._run('pull', *args)

--- a/benchmarking/repos/hg.py
+++ b/benchmarking/repos/hg.py
@@ -23,7 +23,7 @@ class HGRepo(RepoBase):
             hg.append(self.dir)
         hg.append(cmd)
         hg.extend(args)
-        return processRun(hg)[0]
+        return '\n'.join(processRun(hg)[0])
 
     def pull(self, *args):
         return self._run('update', args[0])

--- a/benchmarking/utils/build_program.py
+++ b/benchmarking/utils/build_program.py
@@ -28,7 +28,7 @@ def buildProgramPlatform(dst, repo_dir, framework, frameworks_dir, platform):
         result, _ = processRun(['sh', script, repo_dir, dst])
     if os.path.isfile(dst):
         os.chmod(dst, 0o777)
-    getLogger().info(result)
+    getLogger().info('\n'.join(result))
 
     if not os.path.isfile(dst) and \
             (not (os.path.isdir(dst) and platform.startswith("ios"))):


### PR DESCRIPTION
Without timeout feature introduces a number of issues. Some job being stuck may prevent future jobs from running. 

This diff make several changes:
1. Add timeout to python 2.7
2. processRun returns a list of outputs, one output line per entry. 
3. pre/post process routines only print output when log_output is also set. 
4. remove runAsync from android adb, since it is implemented with the timeout feature.
5. remove runCommand method since it is not used.
6. pass platform_args to all platforms

Test plan:
1. Run ios with/without timeout
2. Run android with/without timeout
3. Run android app with/without timeout
4. Run host with/without timeout

There may still be corner cases not covered by the verification. Need to keep an eye on it.