### PR TITLE
For python2, may need to decode the string, but for python3, cannot d…

### DIFF
--- a/benchmarking/utils/subprocess_with_logger.py
+++ b/benchmarking/utils/subprocess_with_logger.py
@@ -101,6 +101,12 @@ def _getOutput(ps, lines_iterator, patterns):
     match = False
     for line in lines_iterator:
         nline = line.rstrip()
+        try:
+            # decode the string if decode exists
+            decoded_line = nline.decode('utf-8')
+            nline = decoded_line
+        except Exception:
+            pass
         lines.append(nline)
         for pattern in patterns:
             if pattern.match(nline):


### PR DESCRIPTION
…ecode. Use try... except... to make it always work