### PR TITLE
Support benchmarking multiple batches in one binary run

### DIFF
--- a/libraries/python/classification_compare.py
+++ b/libraries/python/classification_compare.py
@@ -46,15 +46,29 @@ class OutputCompare(object):
                 self.args.labels)
 
     def getData(self, filename):
+        num_entries = 0
+        content_list = []
         with open(filename, "r") as f:
-            line = f.readline().strip()
-            dims_list = [int(dim.strip()) for dim in line.split(',')]
-            line = f.readline().strip()
-            content_list = [float(entry.strip()) for entry in line.split(',')]
+            line = f.readline()
+            dim_str = line
+            while (line != ""):
+                assert dim_str == line, \
+                    "The dimensions do not match"
+                num_entries = num_entries + 1
+                dims_list = [int(dim.strip())
+                             for dim in line.strip().split(',')]
+                line = f.readline().strip()
+                content_list.extend([float(entry.strip())
+                                     for entry in line.split(',')])
+                line = f.readline()
+
+        dims_list.insert(0, num_entries)
         dims = np.asarray(dims_list)
         content = np.asarray(content_list)
         data = np.reshape(content, dims)
-        return data.tolist()
+        # reshape to two dimension array
+        benchmark_data = data.reshape((-1, data.shape[-1]))
+        return benchmark_data.tolist()
 
     def writeOneResult(self, values, data, metric, unit):
         entry = {

--- a/libraries/python/coco/generate_im_info.py
+++ b/libraries/python/coco/generate_im_info.py
@@ -46,9 +46,7 @@ class ImInfo(object):
 
     def run(self):
         with open(self.args.dataset_file, "r") as f:
-            imgs = json.load(f)
-        if not isinstance(imgs, list):
-            imgs = [imgs]
+            imgs = [json.loads(s) for s in f.readlines()]
         batch_size = self.args.batch_size \
             if self.args.batch_size > 0 else len(imgs)
 

--- a/libraries/python/coco/json_dataset.py
+++ b/libraries/python/coco/json_dataset.py
@@ -43,8 +43,6 @@ parser.add_argument("--dataset_dir", type=str, required=True,
     help="Dataet image path")
 parser.add_argument("--dataset_ann", type=str, required=True,
     help="Dataet annotation file")
-parser.add_argument("--limit-files", type=int,
-    help="Limit the total number of files to the test set.")
 parser.add_argument("--output-file", type=str, required=True,
     help="The file containing the loaded coco database.")
 parser.add_argument("--output-image-file", type=str,
@@ -98,8 +96,6 @@ class JsonDataset(object):
         image_ids.sort()
 
         roidb = copy.deepcopy(coco.loadImgs(image_ids))
-        if self.args.limit_files:
-            roidb = roidb[:self.args.limit_files]
         for entry in roidb:
             self._prep_roidb_entry(entry)
         with open(self.args.output_file, "w") as f:

--- a/specifications/models/caffe2/MaskRCNN2Go/MaskRCNN2Go_COCO.json
+++ b/specifications/models/caffe2/MaskRCNN2Go/MaskRCNN2Go_COCO.json
@@ -15,7 +15,7 @@
       }
     },
     "format": "caffe2",
-    "images_per_batch": "{total_images}/{repeat}",
+    "images_per_iter": "{total_images}/{repeat}",
     "kind": "deployment",
     "log_output": "true",
     "name": "MaskRCNN2Go",
@@ -23,17 +23,18 @@
     "dataset_ann": "{COCO_DIR}/annotations/instances_val2014.json",
     "postprocess": {
       "commands": [
-        "{FAIPEPROOT}/libraries/python/coco/test_engine.py --dataset coco_2014val --dataset_dir {dataset_dir} --dataset_ann {dataset_ann} --limit-files {total_images} --input-dir {HOSTDIR}/outputs --result-prefix coco_result --output-dir {HOSTDIR}/result"
+        "{FAIPEPROOT}/libraries/python/coco/test_engine.py --dataset coco_2014val --dataset_dir {dataset_dir} --dataset_ann {dataset_ann} --limit-files {repeat} --total-num {total_images} --input-dir {HOSTDIR}/outputs --result-prefix coco_result --output-dir {HOSTDIR}/result"
       ]
     },
     "preprocess": {
       "commands": [
         "mkdir -p {HOSTDIR}/inputs",
         "mkdir -p {HOSTDIR}/outputs",
-        "{FAIPEPROOT}/libraries/python/coco/json_dataset.py --dataset coco_2014val --dataset_dir {dataset_dir} --dataset_ann {dataset_ann} --limit-files {total_images} --output-file {HOSTDIR}/coco_database.txt --output-image-file {HOSTDIR}/coco_images.txt"
+        "{FAIPEPROOT}/libraries/python/coco/json_dataset.py --dataset coco_2014val --dataset_dir {dataset_dir} --dataset_ann {dataset_ann} --output-file {HOSTDIR}/coco_database.txt --output-image-file {HOSTDIR}/coco_images.txt"
       ]
     },
-    "repeat": 50000,
+    "repeat": 1000,
+    "batch_size": 1,
     "total_images": 50000
   },
   "tests": [
@@ -52,7 +53,7 @@
           "location": "{HOSTDIR}/images_tensor.pb"
         }
       },
-      "iter": 1,
+      "iter": 50,
       "log_output": "true",
       "metric": "accuracy",
       "output_files": {
@@ -80,10 +81,10 @@
       },
       "preprocess": {
         "commands": [
-          "awk '(NR>{INDEX}*{images_per_batch})&&(NR<={INDEX}*{images_per_batch}+{images_per_batch}) {print > \"{HOSTDIR}/inputs/coco_database_{INDEX}.txt\"}' {HOSTDIR}/coco_database.txt",
-          "awk '(NR>{INDEX}*{images_per_batch})&&(NR<={INDEX}*{images_per_batch}+{images_per_batch}) {print > \"{HOSTDIR}/inputs/coco_images_{INDEX}.txt\"}' {HOSTDIR}/coco_images.txt",
-          "{FAIPEPROOT}/libraries/python/coco/generate_im_info.py --dataset-file {HOSTDIR}/inputs/coco_database_{INDEX}.txt --min-size 320 --max-size 640 --output-file {HOSTDIR}/inputs/coco_im_info_{INDEX}.txt",
-          "{convert_image_to_tensor} --input_image_file {HOSTDIR}/inputs/coco_images_{INDEX}.txt --output_tensor {input_files.images_tensor} --scale 320,640 --input_text_file {HOSTDIR}/inputs/coco_im_info_{INDEX}.txt --output_text_tensor {input_files.im_info_tensor} --report_time \"json|Caffe2Observer \""
+          "awk '(NR>{INDEX}*{images_per_iter})&&(NR<={INDEX}*{images_per_iter}+{images_per_iter}) {print > \"{HOSTDIR}/inputs/coco_database_{INDEX}.txt\"}' {HOSTDIR}/coco_database.txt",
+          "awk '(NR>{INDEX}*{images_per_iter})&&(NR<={INDEX}*{images_per_iter}+{images_per_iter}) {print > \"{HOSTDIR}/inputs/coco_images_{INDEX}.txt\"}' {HOSTDIR}/coco_images.txt",
+          "{FAIPEPROOT}/libraries/python/coco/generate_im_info.py --dataset-file {HOSTDIR}/inputs/coco_database_{INDEX}.txt --min-size 320 --max-size 640 --batch-size {batch_size} --output-file {HOSTDIR}/inputs/coco_im_info_{INDEX}.txt",
+          "{convert_image_to_tensor} --input_image_file {HOSTDIR}/inputs/coco_images_{INDEX}.txt --output_tensor {input_files.images_tensor} --scale 320,640 --batch_size {batch_size} --input_text_file {HOSTDIR}/inputs/coco_im_info_{INDEX}.txt --output_text_tensor {input_files.im_info_tensor} --report_time \"json|Caffe2Observer \""
         ]
       },
       "warmup": 1

--- a/specifications/models/caffe2/shufflenet/shufflenet_accuracy_imagenet.json
+++ b/specifications/models/caffe2/shufflenet/shufflenet_accuracy_imagenet.json
@@ -6,16 +6,17 @@
       "init": {
         "filename": "model_init.pb",
         "location": "{MODEL_DIR}/model_init.pb",
-        "md5": "b8cd2f6a34a4b2a6b1e60ac65b9a56b4"
+        "md5": ""
       },
       "predict": {
         "filename": "model.pb",
         "location": "{MODEL_DIR}/model.pb",
-        "md5": "1f6e14b7e409006f862c6ab66e60a6f6"
+        "md5": ""
       }
     },
     "format": "caffe2",
-    "images_per_batch": "{total_images}/{repeat}",
+    "images_per_iter": "{total_images}/{repeat}",
+    "batch_size": "1",
     "kind": "deployment",
     "name": "shufflenet",
     "postprocess": {
@@ -30,7 +31,7 @@
         "{FAIPEPROOT}/libraries/python/imagenet_test_map.py --image-dir {IMAGENET_DIR}/val/ --label-file {IMAGENET_DIR}/labels.txt --output-image-file {HOSTDIR}/images.txt --output-label-file {HOSTDIR}/labels.txt --shuffle"
       ]
     },
-    "repeat": 50000,
+    "repeat": 1000,
     "total_images": 50000
   },
   "tests": [
@@ -45,7 +46,7 @@
           "location": "{HOSTDIR}/images_tensor.pb"
         }
       },
-      "iter": 1,
+      "iter": 50,
       "metric": "accuracy",
       "output_files": {
         "softmax": {
@@ -60,8 +61,8 @@
       },
       "preprocess": {
         "commands": [
-          "awk '(NR>{INDEX}*{images_per_batch})&&(NR<={INDEX}*{images_per_batch}+{images_per_batch}) {print > \"{HOSTDIR}/inputs/labels_{INDEX}.txt\"}' {HOSTDIR}/labels.txt",
-          "{convert_image_to_tensor} --input_image_file {HOSTDIR}/inputs/labels_{INDEX}.txt --output_tensor {input_files.images_tensor} --scale \"256,-1\" --crop 224,224 --preprocess normalize,mean,std --report_time \"json|Caffe2Observer \""
+          "awk '(NR>{INDEX}*{images_per_iter})&&(NR<={INDEX}*{images_per_iter}+{images_per_iter}) {print > \"{HOSTDIR}/inputs/labels_{INDEX}.txt\"}' {HOSTDIR}/labels.txt",
+          "{convert_image_to_tensor} --input_image_file {HOSTDIR}/inputs/labels_{INDEX}.txt --output_tensor {input_files.images_tensor} --batch_size {batch_size} --scale \"256,-1\" --crop 224,224 --preprocess normalize,mean,std --report_time \"json|Caffe2Observer \""
         ]
       },
       "warmup": 1


### PR DESCRIPTION
Depends on https://github.com/pytorch/pytorch/pull/15443.

To improve the benchmarking speed, we can now support benchmarking multiple batches in one binary run, which means less model load, warmup etc. This should make long running benchmarking processes faster.