### PR TITLE
change_assert_to_warn

### DIFF
--- a/benchmarking/driver/benchmark_driver.py
+++ b/benchmarking/driver/benchmark_driver.py
@@ -140,12 +140,16 @@ def _mergeDelayData(treatment_data, control_data, bname):
         if "info_string" in treatment_value:
             assert "info_string" in control_value, \
                 "Control value missing info_string field"
-            assert treatment_value["info_string"] == \
-                control_value["info_string"], \
-                "The field info_string in control " + \
-                "({})".format(control_value["info_string"]) + \
-                "is different from the info_string in treatment " + \
-                "({})".format(treatment_value["info_string"])
+            # If the treatment and control are not the same,
+            # treatment value is used, the control value is lost.
+            getLogger().warning(
+                treatment_value["info_string"] ==
+                control_value["info_string"],
+                "Treatment value is used, and the control value is lost. " +
+                "The field info_string in control " +
+                "({})".format(control_value["info_string"]) +
+                "is different from the info_string in treatment " +
+                "({})".format(treatment_value["info_string"]))
 
         if "values" in control_value:
             data[k]["control_values"] = control_value["values"]


### PR DESCRIPTION
In the code https://github.com/facebook/FAI-PEP/blob/master/benchmarking/driver/benchmark_driver.py#L142, we are using assert to compare info_string between control and treatment. In OCR case, most of info_string comparisons are not the same between control and treatment. One example
```
([{alias_dst: None}, {link_internal: None}, {timestep: timestep}, {link_external: None}, {link_offset: None}, {alias_offset: None}, {recurrent_states: None}, {initial_recurrent_state_ids: None}, {step_net: 0x7f1ae64a4020}, {enable_rnn_executor: 1}, {alias_src: None}, ])
is different from the info_string in treatment
([{alias_dst: None}, {link_internal: None}, {timestep: timestep}, {link_external: None}, {link_offset: None}, {alias_offset: None}, {recurrent_states: None}, {initial_recurrent_state_ids: None}, {step_net: 0x7fe8ed09e020}, {enable_ rnn_executor: 1}, {alias_src: None}, ])
```
so the only difference is step_net above. Similar PR has been discussed here https://github.com/facebook/FAI-PEP/pull/109.