### PR TITLE
Add dash and upper cases to regex for iOS devices' hash

### DIFF
--- a/benchmarking/platforms/ios/ios_driver.py
+++ b/benchmarking/platforms/ios/ios_driver.py
@@ -31,7 +31,7 @@ class IOSDriver(object):
         if len(rows) == 0:
             return {}
         rows.pop(0)
-        pattern = re.compile(".* Found ([\d|a-f]+) \((\w+), .+\) a\.k\.a\. .*")
+        pattern = re.compile(".* Found ([\d|a-f|\-|A-F]+) \((\w+), .+\) a\.k\.a\. .*")
         devices = {}
         for row in rows:
             match = pattern.match(row)


### PR DESCRIPTION
On some iOS devices, the hash includes dash (-) characters. This modification makes the script compatible for those devices.