### PR TITLE
change parser style

### DIFF
--- a/benchmarking/benchmarks/benchmarks.py
+++ b/benchmarking/benchmarks/benchmarks.py
@@ -16,14 +16,14 @@ import os
 import requests
 import tempfile
 import shutil
-from utils.arg_parse import getArgs
 from utils.custom_logger import getLogger
 from utils.utilities import deepMerge, deepReplace
 
 
 class BenchmarkCollector(object):
-    def __init__(self, framework, model_cache):
+    def __init__(self, framework, model_cache, **kwargs):
 
+        self.args = kwargs.get('args', None)
         if not os.path.isdir(model_cache):
             os.makedirs(model_cache)
         self.model_cache = model_cache
@@ -37,8 +37,8 @@ class BenchmarkCollector(object):
         meta = content["meta"] if "meta" in content else {}
         if "meta" in info:
             deepMerge(meta, info["meta"])
-        if hasattr(getArgs(), "timeout"):
-            meta["timeout"] = getArgs().timeout
+        if hasattr(self.args, "timeout"):
+            meta["timeout"] = self.args.timeout
         benchmarks = []
 
         if "benchmarks" in content:
@@ -64,8 +64,8 @@ class BenchmarkCollector(object):
         with open(source, 'r') as b:
             one_benchmark = json.load(b)
 
-        string_map = json.loads(getArgs().string_map) \
-            if getArgs().string_map else {}
+        string_map = json.loads(self.args.string_map) \
+            if self.args.string_map else {}
         for name in string_map:
             value = string_map[name]
             deepReplace(one_benchmark, "{" + name + "}", value)
@@ -266,10 +266,10 @@ class BenchmarkCollector(object):
             # Need to download, return the destination filename
             return cache_dir + "/" + filename
         elif location[0:2] == "//":
-            assert getArgs().root_model_dir is not None, \
+            assert self.args.root_model_dir is not None, \
                 "When specifying relative directory, the " \
                 "--root_model_dir must be specified."
-            return getArgs().root_model_dir + location[1:]
+            return self.args.root_model_dir + location[1:]
         elif location[0] != "/":
             abs_dir = os.path.dirname(os.path.abspath(source))
             return os.path.join(abs_dir, location)

--- a/benchmarking/benchmarks/benchmarks.py
+++ b/benchmarking/benchmarks/benchmarks.py
@@ -8,7 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import copy
 import hashlib
 import json

--- a/benchmarking/data_converters/data_converter_base.py
+++ b/benchmarking/data_converters/data_converter_base.py
@@ -8,6 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import abc
 from six import string_types
 

--- a/benchmarking/data_converters/data_converters.py
+++ b/benchmarking/data_converters/data_converters.py
@@ -8,6 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from .json_converter.json_converter import JsonConverter
 from .json_with_identifier_converter.json_with_identifier_converter \

--- a/benchmarking/data_converters/json_converter/json_converter.py
+++ b/benchmarking/data_converters/json_converter/json_converter.py
@@ -8,6 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import collections
 import json
 

--- a/benchmarking/driver/benchmark_driver.py
+++ b/benchmarking/driver/benchmark_driver.py
@@ -46,7 +46,8 @@ def runOneBenchmark(info, benchmark, framework, platform,
             data = _mergeDelayData(data, control, bname)
         if benchmark["tests"][0]["metric"] != "generic":
             data = _adjustData(info, data)
-        meta = _retrieveMeta(info, benchmark, platform, framework, backend, user_identifier)
+        meta = _retrieveMeta(info, benchmark, platform, framework,
+                             backend, user_identifier)
 
         result = {
             "meta": meta,

--- a/benchmarking/driver/benchmark_driver.py
+++ b/benchmarking/driver/benchmark_driver.py
@@ -8,6 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import copy
 import os
 import sys

--- a/benchmarking/frameworks/caffe2/caffe2.py
+++ b/benchmarking/frameworks/caffe2/caffe2.py
@@ -8,6 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import copy
 import os
 

--- a/benchmarking/frameworks/caffe2/caffe2.py
+++ b/benchmarking/frameworks/caffe2/caffe2.py
@@ -19,8 +19,8 @@ class Caffe2Framework(FrameworkBase):
     IDENTIFIER = 'Caffe2Observer '
     NET = 'NET'
 
-    def __init__(self, tempdir):
-        super(Caffe2Framework, self).__init__()
+    def __init__(self, tempdir, args):
+        super(Caffe2Framework, self).__init__(args)
         self.tempdir = os.path.join(tempdir, self.getName())
         os.makedirs(self.tempdir, 0o777)
         # cannot have any variable pass among methods

--- a/benchmarking/frameworks/framework_base.py
+++ b/benchmarking/frameworks/framework_base.py
@@ -8,6 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import abc
 import json
 import os

--- a/benchmarking/frameworks/frameworks.py
+++ b/benchmarking/frameworks/frameworks.py
@@ -8,6 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from .caffe2.caffe2 import Caffe2Framework
 from .generic.generic import GenericFramework

--- a/benchmarking/frameworks/generic/generic.py
+++ b/benchmarking/frameworks/generic/generic.py
@@ -13,7 +13,7 @@ from frameworks.framework_base import FrameworkBase
 
 
 class GenericFramework(FrameworkBase):
-    def __init__(self, tempdir):
+    def __init__(self, tempdir, args):
         self.tempdir = os.path.join(tempdir, self.getName())
         os.makedirs(self.tempdir, 0o777)
 

--- a/benchmarking/frameworks/generic/generic.py
+++ b/benchmarking/frameworks/generic/generic.py
@@ -8,6 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import os
 from frameworks.framework_base import FrameworkBase
 

--- a/benchmarking/frameworks/oculus/oculus.py
+++ b/benchmarking/frameworks/oculus/oculus.py
@@ -8,9 +8,14 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import json
 import os
 import shutil
+
 from frameworks.framework_base import FrameworkBase
 from utils.custom_logger import getLogger
 

--- a/benchmarking/frameworks/oculus/oculus.py
+++ b/benchmarking/frameworks/oculus/oculus.py
@@ -16,7 +16,7 @@ from utils.custom_logger import getLogger
 
 
 class OculusFramework(FrameworkBase):
-    def __init__(self, tempdir):
+    def __init__(self, tempdir, args):
         self.tempdir = os.path.join(tempdir, self.getName())
         os.makedirs(self.tempdir, 0o777)
 

--- a/benchmarking/frameworks/tflite/tflite.py
+++ b/benchmarking/frameworks/tflite/tflite.py
@@ -8,6 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import os
 import re
 from six import string_types

--- a/benchmarking/frameworks/tflite/tflite.py
+++ b/benchmarking/frameworks/tflite/tflite.py
@@ -16,7 +16,7 @@ from frameworks.framework_base import FrameworkBase
 
 
 class TFLiteFramework(FrameworkBase):
-    def __init__(self, tempdir):
+    def __init__(self, tempdir, args):
         super(TFLiteFramework, self).__init__()
         self.tempdir = os.path.join(tempdir, self.getName())
         os.makedirs(self.tempdir, 0o777)

--- a/benchmarking/frameworks/tflite/tflite.py
+++ b/benchmarking/frameworks/tflite/tflite.py
@@ -17,7 +17,7 @@ from frameworks.framework_base import FrameworkBase
 
 class TFLiteFramework(FrameworkBase):
     def __init__(self, tempdir, args):
-        super(TFLiteFramework, self).__init__()
+        super(TFLiteFramework, self).__init__(args)
         self.tempdir = os.path.join(tempdir, self.getName())
         os.makedirs(self.tempdir, 0o777)
 

--- a/benchmarking/get_connected_devices.py
+++ b/benchmarking/get_connected_devices.py
@@ -8,10 +8,7 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import argparse
 import json

--- a/benchmarking/get_connected_devices.py
+++ b/benchmarking/get_connected_devices.py
@@ -13,43 +13,44 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import argparse
 import json
 import logging
 
 from platforms.platforms import getPlatforms
-from utils.arg_parse import getParser, parse
 from utils.custom_logger import getLogger
 
-
-getParser().add_argument("-d", "--devices",
+parser = argparse.ArgumentParser()
+parser.add_argument("-d", "--devices",
     help="Specify the devices to run the benchmark, in a comma separated "
     "list. The value is the device or device_hash field of the meta info.")
-getParser().add_argument("--device",
+parser.add_argument("--device",
     help="The single device to run this benchmark on")
-getParser().add_argument("--excluded_devices",
+parser.add_argument("--excluded_devices",
     help="Specify the devices that skip the benchmark, in a comma separated "
     "list. The value is the device or device_hash field of the meta info.")
-getParser().add_argument("--set_freq",
+parser.add_argument("--set_freq",
     help="On rooted android phones, set the frequency of the cores. "
     "The supported values are: "
     "max: set all cores to the maximum frquency. "
     "min: set all cores to the minimum frequency. "
     "mid: set all cores to the median frequency. ")
-getParser().add_argument("--platform", default="android",
+parser.add_argument("--platform", default="android",
     help="Specify the platforms to benchmark on. ")
-getParser().add_argument("--platform_sig",
+parser.add_argument("--platform_sig",
     help="Specify the platforms signature which clusters the same type machine. ")
-getParser().add_argument("--hash_platform_mapping",
+parser.add_argument("--hash_platform_mapping",
     help="Specify the devices hash platform mapping json file.")
 
 
 class GetConnectedDevices(object):
-    def __init__(self):
+    def __init__(self, **kwargs):
         getLogger().setLevel(logging.FATAL)
-        parse()
+        raw_args = kwargs.get("raw_args", None)
+        self.args, self.unknowns = parser.parse_known_args(raw_args)
 
     def run(self):
-        platforms = getPlatforms("/tmp")
+        platforms = getPlatforms("/tmp", self.args)
         devices = []
         for p in platforms:
             devices.append({

--- a/benchmarking/get_connected_devices.py
+++ b/benchmarking/get_connected_devices.py
@@ -8,8 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import argparse
 import json
 import logging

--- a/benchmarking/harness.py
+++ b/benchmarking/harness.py
@@ -8,6 +8,7 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+import argparse
 import copy
 import json
 import os
@@ -22,140 +23,145 @@ from benchmarks.benchmarks import BenchmarkCollector
 from frameworks.frameworks import getFrameworks
 from platforms.platforms import getPlatforms
 from reporters.reporters import getReporters
-from utils.arg_parse import getParser, getArgs, parseKnown
 from utils.custom_logger import getLogger
 from utils.utilities import parse_kwarg, getRunStatus
 
+parser = argparse.ArgumentParser()
+parser.add_argument("--android_dir", default="/data/local/tmp/",
+    help="The directory in the android device all files are pushed to.")
 # for backward compatible purpose
-getParser().add_argument("--backend",
+parser.add_argument("--backend",
     help="Specify the backend the test runs on.")
-getParser().add_argument("-b", "--benchmark_file", required=True,
+parser.add_argument("-b", "--benchmark_file", required=True,
     help="Specify the json file for the benchmark or a number of benchmarks")
-getParser().add_argument("--command_args",
+parser.add_argument("--command_args",
     help="Specify optional command arguments that would go with the "
     "main benchmark command")
-getParser().add_argument("--cooldown", default=0, type=float,
+parser.add_argument("--cooldown", default=0, type=float,
     help = "Specify the time interval between two test runs.")
-getParser().add_argument("--debug", action="store_true",
+parser.add_argument("--debug", action="store_true",
     help="Debug mode to retain all the running binaries and models.")
-getParser().add_argument("--device",
+parser.add_argument("--device",
     help="The single device to run this benchmark on")
-getParser().add_argument("-d", "--devices",
+parser.add_argument("-d", "--devices",
     help="Specify the devices to run the benchmark, in a comma separated "
     "list. The value is the device or device_hash field of the meta info.")
-getParser().add_argument("--env", help="environment variables passed to runtime binary.",
+parser.add_argument("--env", help="environment variables passed to runtime binary.",
     nargs="*", type=parse_kwarg, default=[])
-getParser().add_argument("--excluded_devices",
+parser.add_argument("--excluded_devices",
     help="Specify the devices that skip the benchmark, in a comma separated "
     "list. The value is the device or device_hash field of the meta info.")
-getParser().add_argument("--framework", required=True,
+parser.add_argument("--framework", required=True,
     choices=["caffe2", "generic", "oculus", "tflite"],
     help="Specify the framework to benchmark on.")
-getParser().add_argument("--info", required=True,
+parser.add_argument("--info", required=True,
     help="The json serialized options describing the control and treatment.")
-getParser().add_argument("--local_reporter",
+parser.add_argument("--ios_dir", default="/tmp",
+    help="The directory in the ios device all files are pushed to.")
+parser.add_argument("--local_reporter",
     help="Save the result to a directory specified by this argument.")
-getParser().add_argument("--monsoon_map",
+parser.add_argument("--monsoon_map",
     help="Map the phone hash to the monsoon serial number.")
-getParser().add_argument("--simple_local_reporter",
+parser.add_argument("--simple_local_reporter",
     help="Same as local reporter, but the directory hierarchy is reduced.")
-getParser().add_argument("--model_cache", required=True,
+parser.add_argument("--model_cache", required=True,
     help="The local directory containing the cached models. It should not "
     "be part of a git directory.")
-getParser().add_argument("-p", "--platform", required=True,
+parser.add_argument("-p", "--platform", required=True,
     help="Specify the platform to benchmark on. Use this flag if the framework"
     " needs special compilation scripts. The scripts are called build.sh "
     "saved in " + os.path.join("specifications",
     "frameworks", "<framework>", "<platform>") + " directory")
-getParser().add_argument("--platform_sig",
+parser.add_argument("--platform_sig",
     help="Specify the platform signature")
-getParser().add_argument("--program",
+parser.add_argument("--program",
     help="The program to run on the platform.")
-getParser().add_argument("--reboot", action="store_true",
+parser.add_argument("--reboot", action="store_true",
     help="Tries to reboot the devices before launching benchmarks for one "
     "commit.")
-getParser().add_argument("--regressed_types",
+parser.add_argument("--regressed_types",
     help="A json string that encodes the types of the regressed tests.")
-getParser().add_argument("--remote_reporter",
+parser.add_argument("--remote_reporter",
     help="Save the result to a remote server. "
     "The style is <domain_name>/<endpoint>|<category>")
-getParser().add_argument("--remote_access_token",
+parser.add_argument("--remote_access_token",
     help="The access token to access the remote server")
-getParser().add_argument("--root_model_dir",
+parser.add_argument("--root_model_dir",
     help="The root model directory if the meta data of the model uses "
     "relative directory, i.e. the location field starts with //")
-getParser().add_argument("--run_type", default="benchmark",
+parser.add_argument("--run_type", default="benchmark",
     choices=["benchmark", "verify", "regress"],
     help="The type of the current run. The allowed values are: "
     "benchmark, the normal benchmark run."
     "verify, the benchmark is re-run to confirm a suspicious regression."
     "regress, the regression is confirmed.")
-getParser().add_argument("--screen_reporter", action="store_true",
+parser.add_argument("--screen_reporter", action="store_true",
     help="Display the summary of the benchmark result on screen.")
-getParser().add_argument("--simple_screen_reporter", action="store_true",
+parser.add_argument("--simple_screen_reporter", action="store_true",
     help="Display the result on screen with no post processing.")
-getParser().add_argument("--set_freq",
+parser.add_argument("--set_freq",
     help="On rooted android phones, set the frequency of the cores. "
     "The supported values are: "
     "max: set all cores to the maximum frquency. "
     "min: set all cores to the minimum frequency. "
     "mid: set all cores to the median frequency. ")
-getParser().add_argument("--shared_libs",
+parser.add_argument("--shared_libs",
     help="Pass the shared libs that the framework depends on, "
     "in a comma separated list.")
-getParser().add_argument("--string_map",
+parser.add_argument("--string_map",
     help="A json string mapping tokens to replacement strings. "
     "The tokens, surrended by \{\}, when appearing in the test fields of "
     "the json file, are to be replaced with the mapped values.")
-getParser().add_argument("--timeout", default=300, type=float,
+parser.add_argument("--timeout", default=300, type=float,
     help="Specify a timeout running the test on the platforms. "
     "The timeout value needs to be large enough so that the low end devices "
     "can safely finish the execution in normal conditions. ")
-getParser().add_argument("--user_identifier",
+parser.add_argument("--user_identifier",
     help="User can specify an identifier and that will be passed to the "
     "output so that the result can be easily identified.")
 # for backward compabile purpose
-getParser().add_argument("--wipe_cache", default=False,
+parser.add_argument("--wipe_cache", default=False,
     help="Specify whether to evict cache or not before running")
-getParser().add_argument("--hash_platform_mapping",
+parser.add_argument("--hash_platform_mapping",
     help="Specify the devices hash platform mapping json file.")
 # Avoid the prefix user so that it doesn't collide with --user_identifier
-getParser().add_argument("--user_string",
+parser.add_argument("--user_string",
     help="Specify the user running the test (to be passed to the remote reporter).")
 
 
 class BenchmarkDriver(object):
-    def __init__(self):
-        parseKnown()
+    def __init__(self, **kwargs):
+        raw_args = kwargs.get("raw_args", None)
+        self.args, self.unknowns = parser.parse_known_args(raw_args)
         self._lock = threading.Lock()
         self.status = 0
 
     def runBenchmark(self, info, platform, benchmarks):
-        if getArgs().reboot:
+        if self.args.reboot:
             platform.rebootDevice()
         for idx in range(len(benchmarks)):
             tempdir = tempfile.mkdtemp()
             # we need to get a different framework instance per thread
             # will consolidate later. For now create a new framework
             frameworks = getFrameworks()
-            framework = frameworks[getArgs().framework](tempdir)
-            reporters = getReporters()
+            framework = frameworks[self.args.framework](tempdir, self.args)
+            reporters = getReporters(self.args)
 
             benchmark = benchmarks[idx]
             # check the framework matches
             if "model" in benchmark and "framework" in benchmark["model"]:
                 assert(benchmark["model"]["framework"] ==
-                       getArgs().framework), \
+                       self.args.framework), \
                     "Framework specified in the json file " \
                     "{} ".format(benchmark["model"]["framework"]) + \
                     "does not match the command line argument " \
-                    "{}".format(getArgs().framework)
-            if getArgs().debug:
+                    "{}".format(self.args.framework)
+            if self.args.debug:
                 for test in benchmark["tests"]:
                     test["log_output"] = True
-            if getArgs().env:
+            if self.args.env:
                 for test in benchmark["tests"]:
-                    cmd_env = dict(getArgs().env)
+                    cmd_env = dict(self.args.env)
                     if "env" in test:
                         cmd_env.update(test["env"])
                     test["env"] = cmd_env
@@ -163,16 +169,19 @@ class BenchmarkDriver(object):
             b = copy.deepcopy(benchmark)
             i = copy.deepcopy(info)
             status = runOneBenchmark(i, b, framework, platform,
-                                     getArgs().platform,
-                                     reporters, self._lock)
+                                     self.args.platform,
+                                     reporters, self._lock,
+                                     self.args.cooldown,
+                                     self.args.user_identifier,
+                                     self.args.local_reporter)
             self.status = self.status | status
             if idx != len(benchmarks) - 1:
                 # cool down period between multiple benchmark runs
-                cooldown = getArgs().cooldown
+                cooldown = self.args.cooldown
                 if "model" in benchmark and "cooldown" in benchmark["model"]:
                     cooldown = float(benchmark["model"]["cooldown"])
                 time.sleep(cooldown)
-            if not getArgs().debug:
+            if not self.args.debug:
                 shutil.rmtree(tempdir, True)
 
     def run(self):
@@ -180,13 +189,14 @@ class BenchmarkDriver(object):
         getLogger().info("Temp directory: {}".format(tempdir))
         info = self._getInfo()
         frameworks = getFrameworks()
-        assert getArgs().framework in frameworks, \
-            "Framework {} is not supported".format(getArgs().framework)
-        framework = frameworks[getArgs().framework](tempdir)
-        bcollector = BenchmarkCollector(framework, getArgs().model_cache)
+        assert self.args.framework in frameworks, \
+            "Framework {} is not supported".format(self.args.framework)
+        framework = frameworks[self.args.framework](tempdir, self.args)
+        bcollector = BenchmarkCollector(framework, self.args.model_cache,
+                                        args=self.args)
         benchmarks = bcollector.collectBenchmarks(info,
-                                                  getArgs().benchmark_file)
-        platforms = getPlatforms(tempdir)
+                                                  self.args.benchmark_file)
+        platforms = getPlatforms(tempdir, self.args)
         threads = []
         for platform in platforms:
             t = threading.Thread(target=self.runBenchmark,
@@ -196,26 +206,26 @@ class BenchmarkDriver(object):
         for t in threads:
             t.join()
 
-        if not getArgs().debug:
+        if not self.args.debug:
             shutil.rmtree(tempdir, True)
 
     def _getInfo(self):
-        info = json.loads(getArgs().info)
+        info = json.loads(self.args.info)
         info["run_type"] = "benchmark"
         if "meta" not in info:
             info["meta"] = {}
-        info["meta"]["command_args"] = getArgs().command_args \
-            if getArgs().command_args else ""
+        info["meta"]["command_args"] = self.args.command_args \
+            if self.args.command_args else ""
 
         # for backward compatible purpose
-        if getArgs().backend:
+        if self.args.backend:
             info["meta"]["command_args"] += \
-                " --backend {}".format(getArgs().backend)
-        if getArgs().wipe_cache:
+                " --backend {}".format(self.args.backend)
+        if self.args.wipe_cache:
             info["meta"]["command_args"] += \
-                " --wipe_cache {}".format(getArgs().wipe_cache)
-        if getArgs().user_string:
-            info["user"] = getArgs().user_string
+                " --wipe_cache {}".format(self.args.wipe_cache)
+        if self.args.user_string:
+            info["user"] = self.args.user_string
 
         return info
 

--- a/benchmarking/harness.py
+++ b/benchmarking/harness.py
@@ -8,6 +8,7 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import, division, print_function, unicode_literals
 import argparse
 import copy
 import json

--- a/benchmarking/harness.py
+++ b/benchmarking/harness.py
@@ -114,7 +114,7 @@ parser.add_argument("--shared_libs",
     "in a comma separated list.")
 parser.add_argument("--string_map",
     help="A json string mapping tokens to replacement strings. "
-    "The tokens, surrended by \{\}, when appearing in the test fields of "
+    "The tokens, surrended by {}, when appearing in the test fields of "
     "the json file, are to be replaced with the mapped values.")
 parser.add_argument("--timeout", default=300, type=float,
     help="Specify a timeout running the test on the platforms. "
@@ -154,8 +154,7 @@ class BenchmarkDriver(object):
             benchmark = benchmarks[idx]
             # check the framework matches
             if "model" in benchmark and "framework" in benchmark["model"]:
-                assert(benchmark["model"]["framework"] ==
-                       self.args.framework), \
+                assert(benchmark["model"]["framework"] == self.args.framework), \
                     "Framework specified in the json file " \
                     "{} ".format(benchmark["model"]["framework"]) + \
                     "does not match the command line argument " \

--- a/benchmarking/harness.py
+++ b/benchmarking/harness.py
@@ -213,6 +213,18 @@ class BenchmarkDriver(object):
         if not self.args.debug:
             shutil.rmtree(tempdir, True)
 
+        status = self.status | getRunStatus()
+        if status == 0:
+            status_str = "success"
+        elif status == 1:
+            status_str = "user error"
+        elif status == 2:
+            status_str = "harness error"
+        else:
+            status_str = "user and harness error"
+        getLogger().info(" ======= {} =======".format(status_str))
+        sys.exit(status)
+
     def _getInfo(self):
         info = json.loads(self.args.info)
         info["run_type"] = "benchmark"
@@ -237,14 +249,3 @@ class BenchmarkDriver(object):
 if __name__ == "__main__":
     app = BenchmarkDriver()
     app.run()
-    status = app.status | getRunStatus()
-    if status == 0:
-        status_str = "success"
-    elif status == 1:
-        status_str = "user error"
-    elif status == 2:
-        status_str = "harness error"
-    else:
-        status_str = "user and harness error"
-    getLogger().info(" ======= {} =======".format(status_str))
-    sys.exit(status)

--- a/benchmarking/harness.py
+++ b/benchmarking/harness.py
@@ -8,7 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import argparse
 import copy
 import json

--- a/benchmarking/platforms/android/adb.py
+++ b/benchmarking/platforms/android/adb.py
@@ -8,6 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import re
 from six import string_types
 

--- a/benchmarking/platforms/android/android_driver.py
+++ b/benchmarking/platforms/android/android_driver.py
@@ -8,6 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import json
 from six import string_types
 

--- a/benchmarking/platforms/android/android_driver.py
+++ b/benchmarking/platforms/android/android_driver.py
@@ -13,11 +13,11 @@ from six import string_types
 
 from platforms.android.adb import ADB
 from platforms.android.android_platform import AndroidPlatform
-from utils.arg_parse import getArgs
 
 
 class AndroidDriver:
-    def __init__(self, devices=None):
+    def __init__(self, args, devices=None):
+        self.args = args
         if devices:
             if isinstance(devices, string_types):
                 devices = [devices]
@@ -38,16 +38,16 @@ class AndroidDriver:
 
     def getAndroidPlatforms(self, tempdir):
         platforms = []
-        if getArgs().device:
+        if self.args.device:
             device = None
-            device_str = getArgs().device
+            device_str = self.args.device
             if device_str[0] == '{':
                 device = json.loads(device_str)
                 hash = device["hash"]
             else:
-                hash = getArgs().device
+                hash = self.args.device
             adb = ADB(hash, tempdir)
-            platform = AndroidPlatform(tempdir, adb)
+            platform = AndroidPlatform(tempdir, adb, self.args)
             platforms.append(platform)
             if device:
                 platform.setPlatform(device["kind"])
@@ -55,17 +55,17 @@ class AndroidDriver:
 
         if self.devices is None:
             self.devices = self.getDevices()
-        if getArgs().excluded_devices:
+        if self.args.excluded_devices:
             excluded_devices = \
-                set(getArgs().excluded_devices.strip().split(','))
+                set(self.args.excluded_devices.strip().split(','))
             self.devices = self.devices.difference(excluded_devices)
 
-        if getArgs().devices:
-            supported_devices = set(getArgs().devices.strip().split(','))
+        if self.args.devices:
+            supported_devices = set(self.args.devices.strip().split(','))
             if supported_devices.issubset(self.devices):
                 self.devices = supported_devices
 
         for device in self.devices:
             adb = ADB(device, tempdir)
-            platforms.append(AndroidPlatform(tempdir, adb))
+            platforms.append(AndroidPlatform(tempdir, adb, self.args))
         return platforms

--- a/benchmarking/platforms/android/android_platform.py
+++ b/benchmarking/platforms/android/android_platform.py
@@ -158,7 +158,7 @@ class AndroidPlatform(PlatformBase):
                 # to go into sleep mode
                 self.util.shell(["am", "start", "-a",
                                 "android.settings.SETTINGS"])
-                time.sleep(10)
+                time.sleep(1)
                 cmd = ["nohup"] + ["sh", "-c", "'" + " ".join(cmd) + "'"] + \
                     [">", "/dev/null", "2>&1"]
                 platform_args["non_blocking"] = True

--- a/benchmarking/platforms/android/android_platform.py
+++ b/benchmarking/platforms/android/android_platform.py
@@ -27,7 +27,7 @@ from utils.utilities import getRunStatus, setRunStatus
 class AndroidPlatform(PlatformBase):
     def __init__(self, tempdir, adb, args):
         super(AndroidPlatform, self).__init__(
-            tempdir, args.android_dir, adb, args)
+            tempdir, args.android_dir, adb, args.hash_platform_mapping)
         self.args = args
         platform = adb.shell(
             ['getprop', 'ro.product.model'], default="")[0].strip() + \

--- a/benchmarking/platforms/android/android_platform.py
+++ b/benchmarking/platforms/android/android_platform.py
@@ -8,6 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import json
 import os
 import re

--- a/benchmarking/platforms/android/android_platform.py
+++ b/benchmarking/platforms/android/android_platform.py
@@ -16,18 +16,15 @@ import shutil
 import time
 
 from platforms.platform_base import PlatformBase
-from utils.arg_parse import getParser, getArgs
 from utils.custom_logger import getLogger
 from utils.utilities import getRunStatus, setRunStatus
 
-getParser().add_argument("--android_dir", default="/data/local/tmp/",
-    help="The directory in the android device all files are pushed to.")
-
 
 class AndroidPlatform(PlatformBase):
-    def __init__(self, tempdir, adb):
+    def __init__(self, tempdir, adb, args):
         super(AndroidPlatform, self).__init__(
-            tempdir, getArgs().android_dir, adb)
+            tempdir, args.android_dir, adb, args)
+        self.args = args
         platform = adb.shell(
             ['getprop', 'ro.product.model'], default="")[0].strip() + \
             '-' + \
@@ -40,8 +37,8 @@ class AndroidPlatform(PlatformBase):
         self.setPlatformHash(adb.device)
         self._setLogCatSize()
         self.app = None
-        if getArgs().set_freq:
-            self.util.setFrequency(getArgs().set_freq)
+        if self.args.set_freq:
+            self.util.setFrequency(self.args.set_freq)
 
     def _setLogCatSize(self):
         repeat = True
@@ -98,8 +95,8 @@ class AndroidPlatform(PlatformBase):
         time.sleep(20)
         # may need to set log size again after reboot
         self._setLogCatSize()
-        if getArgs().set_freq:
-            self.util.setFrequency(getArgs().set_freq)
+        if self.args.set_freq:
+            self.util.setFrequency(self.args.set_freq)
 
     def runBenchmark(self, cmd, *args, **kwargs):
         if not isinstance(cmd, list):
@@ -161,7 +158,7 @@ class AndroidPlatform(PlatformBase):
                 # to go into sleep mode
                 self.util.shell(["am", "start", "-a",
                                 "android.settings.SETTINGS"])
-                time.sleep(1)
+                time.sleep(10)
                 cmd = ["nohup"] + ["sh", "-c", "'" + " ".join(cmd) + "'"] + \
                     [">", "/dev/null", "2>&1"]
                 platform_args["non_blocking"] = True

--- a/benchmarking/platforms/host/hdb.py
+++ b/benchmarking/platforms/host/hdb.py
@@ -8,6 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import os
 import shutil
 

--- a/benchmarking/platforms/host/host_platform.py
+++ b/benchmarking/platforms/host/host_platform.py
@@ -17,21 +17,20 @@ import socket
 
 from platforms.host.hdb import HDB
 from platforms.platform_base import PlatformBase
-from utils.arg_parse import getArgs
 from utils.subprocess_with_logger import processRun
 
 
 class HostPlatform(PlatformBase):
-    def __init__(self, tempdir):
+    def __init__(self, tempdir, args):
         platform_hash = str(socket.gethostname())
-        if getArgs().platform_sig is not None:
-            platform_name = str(getArgs().platform_sig)
+        if args.platform_sig is not None:
+            platform_name = str(args.platform_sig)
         else:
             platform_name = platform.platform() + "-" + \
                                self._getProcessorName()
         self.tempdir = os.path.join(tempdir, platform_hash)
         hdb = HDB(platform_hash, tempdir)
-        super(HostPlatform, self).__init__(self.tempdir, self.tempdir, hdb)
+        super(HostPlatform, self).__init__(self.tempdir, self.tempdir, hdb, args)
 
         # reset the platform and platform hash
         self.setPlatform(platform_name)

--- a/benchmarking/platforms/host/host_platform.py
+++ b/benchmarking/platforms/host/host_platform.py
@@ -8,6 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import platform
 import os
 import re

--- a/benchmarking/platforms/host/host_platform.py
+++ b/benchmarking/platforms/host/host_platform.py
@@ -34,7 +34,8 @@ class HostPlatform(PlatformBase):
                                self._getProcessorName()
         self.tempdir = os.path.join(tempdir, platform_hash)
         hdb = HDB(platform_hash, tempdir)
-        super(HostPlatform, self).__init__(self.tempdir, self.tempdir, hdb, args)
+        super(HostPlatform, self).__init__(self.tempdir, self.tempdir, hdb,
+                                           args.hash_platform_mapping)
 
         # reset the platform and platform hash
         self.setPlatform(platform_name)

--- a/benchmarking/platforms/ios/idb.py
+++ b/benchmarking/platforms/ios/idb.py
@@ -8,6 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import os
 import shutil
 import sys

--- a/benchmarking/platforms/ios/ios_driver.py
+++ b/benchmarking/platforms/ios/ios_driver.py
@@ -8,6 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import json
 import re
 from six import string_types

--- a/benchmarking/platforms/ios/ios_driver.py
+++ b/benchmarking/platforms/ios/ios_driver.py
@@ -14,11 +14,11 @@ from six import string_types
 
 from platforms.ios.idb import IDB
 from platforms.ios.ios_platform import IOSPlatform
-from utils.arg_parse import getArgs
 
 
 class IOSDriver(object):
-    def __init__(self, devices=None):
+    def __init__(self, args, devices=None):
+        self.args = args
         if devices:
             if isinstance(devices, string_types):
                 devices = [devices]
@@ -43,25 +43,25 @@ class IOSDriver(object):
 
     def getIOSPlatforms(self, tempdir):
         platforms = []
-        if getArgs().device:
-            device_str = getArgs().device
+        if self.args.device:
+            device_str = self.args.device
             assert device_str[0] == '{', "device must be a json string"
             device = json.loads(device_str)
             idb = IDB(device["hash"], tempdir)
-            platform = IOSPlatform(tempdir, idb)
+            platform = IOSPlatform(tempdir, idb, self.args)
             platform.setPlatform(device["kind"])
             platforms.append(platform)
             return platforms
 
         if self.devices is None:
             self.devices = self.getDevices()
-        if getArgs().excluded_devices:
+        if self.args.excluded_devices:
             excluded_devices = \
-                set(getArgs().excluded_devices.strip().split(','))
+                set(self.args.excluded_devices.strip().split(','))
             self.devices = self.devices.difference(excluded_devices)
 
-        if getArgs().devices:
-            supported_devices = set(getArgs().devices.strip().split(','))
+        if self.args.devices:
+            supported_devices = set(self.args.devices.strip().split(','))
             if supported_devices.issubset(self.devices):
                 self.devices = supported_devices
 

--- a/benchmarking/platforms/ios/ios_platform.py
+++ b/benchmarking/platforms/ios/ios_platform.py
@@ -14,18 +14,14 @@ import shlex
 import time
 
 from platforms.platform_base import PlatformBase
-from utils.arg_parse import getParser, getArgs
 from utils.custom_logger import getLogger
 from utils.subprocess_with_logger import processRun
 from utils.utilities import getRunStatus, setRunStatus
 
-getParser().add_argument("--ios_dir", default="/tmp",
-    help="The directory in the ios device all files are pushed to.")
-
 
 class IOSPlatform(PlatformBase):
-    def __init__(self, tempdir, idb):
-        super(IOSPlatform, self).__init__(tempdir, getArgs().ios_dir, idb)
+    def __init__(self, tempdir, idb, args):
+        super(IOSPlatform, self).__init__(tempdir, args.ios_dir, idb, args)
         self.setPlatformHash(idb.device)
         self.type = "ios"
         self.app = None

--- a/benchmarking/platforms/ios/ios_platform.py
+++ b/benchmarking/platforms/ios/ios_platform.py
@@ -25,7 +25,8 @@ from utils.utilities import getRunStatus, setRunStatus
 
 class IOSPlatform(PlatformBase):
     def __init__(self, tempdir, idb, args):
-        super(IOSPlatform, self).__init__(tempdir, args.ios_dir, idb, args)
+        super(IOSPlatform, self).__init__(tempdir, args.ios_dir, idb,
+                                          args.hash_platform_mapping)
         self.setPlatformHash(idb.device)
         self.type = "ios"
         self.app = None

--- a/benchmarking/platforms/ios/ios_platform.py
+++ b/benchmarking/platforms/ios/ios_platform.py
@@ -8,6 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import json
 import os
 import shlex

--- a/benchmarking/platforms/platform_base.py
+++ b/benchmarking/platforms/platform_base.py
@@ -22,7 +22,7 @@ from utils.utilities import getFilename
 
 
 class PlatformBase(object):
-    def __init__(self, tempdir, tgt_dir, platform_util, args):
+    def __init__(self, tempdir, tgt_dir, platform_util, hash_platform_mapping):
         self.tempdir = tempdir
         self.platform = None
         self.platform_hash = platform_util.device
@@ -30,9 +30,9 @@ class PlatformBase(object):
         self.util = platform_util
         self.tgt_dir = tgt_dir
         self.hash_platform_mapping = None
-        if args.hash_platform_mapping:
+        if hash_platform_mapping:
             try:
-                with open(args.hash_platform_mapping) as f:
+                with open(hash_platform_mapping) as f:
                     self.hash_platform_mapping = json.load(f)
             except OSError as e:
                 getLogger().info("OSError: {}".format(e))

--- a/benchmarking/platforms/platform_base.py
+++ b/benchmarking/platforms/platform_base.py
@@ -13,13 +13,12 @@ import json
 import os
 from six import string_types
 
-from utils.arg_parse import getArgs
 from utils.custom_logger import getLogger
 from utils.utilities import getFilename
 
 
 class PlatformBase(object):
-    def __init__(self, tempdir, tgt_dir, platform_util):
+    def __init__(self, tempdir, tgt_dir, platform_util, args):
         self.tempdir = tempdir
         self.platform = None
         self.platform_hash = platform_util.device
@@ -27,9 +26,9 @@ class PlatformBase(object):
         self.util = platform_util
         self.tgt_dir = tgt_dir
         self.hash_platform_mapping = None
-        if getArgs().hash_platform_mapping:
+        if args.hash_platform_mapping:
             try:
-                with open(getArgs().hash_platform_mapping) as f:
+                with open(args.hash_platform_mapping) as f:
                     self.hash_platform_mapping = json.load(f)
             except OSError as e:
                 getLogger().info("OSError: {}".format(e))

--- a/benchmarking/platforms/platform_base.py
+++ b/benchmarking/platforms/platform_base.py
@@ -8,6 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import abc
 import json
 import os

--- a/benchmarking/platforms/platform_util_base.py
+++ b/benchmarking/platforms/platform_util_base.py
@@ -8,6 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import abc
 
 from utils.subprocess_with_logger import processRun

--- a/benchmarking/platforms/platforms.py
+++ b/benchmarking/platforms/platforms.py
@@ -8,6 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import os
 
 from .android.android_driver import AndroidDriver

--- a/benchmarking/platforms/platforms.py
+++ b/benchmarking/platforms/platforms.py
@@ -14,31 +14,30 @@ from .android.android_driver import AndroidDriver
 from .host.host_platform import HostPlatform
 from .ios.ios_driver import IOSDriver
 from .windows.windows_platform import WindowsPlatform
-from utils.arg_parse import getArgs
 from utils.custom_logger import getLogger
 
 
-def getPlatforms(tempdir):
+def getPlatforms(tempdir, args):
     platforms = []
-    if getArgs().platform[:4] == "host" or \
-       getArgs().platform[:5] == "linux" or \
-       getArgs().platform[:3] == "mac":
-        platforms.append(HostPlatform(tempdir))
-    elif getArgs().platform[:7] == "android":
-        driver = AndroidDriver()
+    if args.platform[:4] == "host" or \
+       args.platform[:5] == "linux" or \
+       args.platform[:3] == "mac":
+        platforms.append(HostPlatform(tempdir, args))
+    elif args.platform[:7] == "android":
+        driver = AndroidDriver(args)
         platforms.extend(driver.getAndroidPlatforms(tempdir))
-        if getArgs().excluded_devices:
-            excluded_devices = getArgs().excluded_devices.strip().split(',')
+        if args.excluded_devices:
+            excluded_devices = args.excluded_devices.strip().split(',')
             platforms = \
                 [p for p in platforms if p.platform not in excluded_devices and
                  (p.platform_hash is None or
                   p.platform_hash not in excluded_devices)]
-        if getArgs().devices:
-            plts = getArgs().devices.strip().split(',')
+        if args.devices:
+            plts = args.devices.strip().split(',')
             platforms = [p for p in platforms if p.platform in plts or
                          p.platform_hash in plts]
-    elif getArgs().platform.startswith("ios"):
-        driver = IOSDriver()
+    elif args.platform.startswith("ios"):
+        driver = IOSDriver(args)
         platforms.extend(driver.getIOSPlatforms(tempdir))
     elif os.name == "nt":
         platforms.append(WindowsPlatform(tempdir))
@@ -47,8 +46,8 @@ def getPlatforms(tempdir):
     return platforms
 
 
-def getHostPlatform(tempdir):
+def getHostPlatform(tempdir, args):
     if os.name == "nt":
         return WindowsPlatform(tempdir)
     else:
-        return HostPlatform(tempdir)
+        return HostPlatform(tempdir, args)

--- a/benchmarking/platforms/windows/windows_platform.py
+++ b/benchmarking/platforms/windows/windows_platform.py
@@ -8,6 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from platforms.host.host_platform import HostPlatform
 

--- a/benchmarking/reboot_device.py
+++ b/benchmarking/reboot_device.py
@@ -8,6 +8,7 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import, division, print_function, unicode_literals
 import argparse
 
 from platforms.android.adb import ADB

--- a/benchmarking/reboot_device.py
+++ b/benchmarking/reboot_device.py
@@ -8,7 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import argparse
 
 from platforms.android.adb import ADB

--- a/benchmarking/reboot_device.py
+++ b/benchmarking/reboot_device.py
@@ -8,24 +8,24 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+import argparse
+
 from platforms.android.adb import ADB
 from platforms.ios.idb import IDB
 
-
-from utils.arg_parse import getParser, getArgs, parse
-
-getParser().add_argument("--device", required=True,
+parser = argparse.ArgumentParser()
+parser.add_argument("--device", required=True,
     help="Specify the device hash to reboot")
-
-getParser().add_argument("-p", "--platform", required=True,
+parser.add_argument("-p", "--platform", required=True,
     help="Specify the platform to benchmark on. "
         "Must starts with ios or android")
 
 
-def reboot():
-    parse()
-    device = getArgs().device
-    platform = getArgs().platform
+def reboot(**kwargs):
+    raw_args = kwargs.get("raw_args", None)
+    args, _ = parser.parse_known_args(raw_args)
+    device = args.device
+    platform = args.platform
     if platform.startswith("ios"):
         util = IDB(device)
     elif platform.startswith("android"):

--- a/benchmarking/regression_detectors/delay_detector/delay_detector.py
+++ b/benchmarking/regression_detectors/delay_detector/delay_detector.py
@@ -8,6 +8,11 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from regression_detectors.regression_detector_base \
     import RegressionDetectorBase
 from utils.custom_logger import getLogger

--- a/benchmarking/regression_detectors/regression_detector_base.py
+++ b/benchmarking/regression_detectors/regression_detector_base.py
@@ -8,6 +8,11 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 
 class RegressionDetectorBase(object):
     def __init__(self):

--- a/benchmarking/regression_detectors/regression_detectors.py
+++ b/benchmarking/regression_detectors/regression_detectors.py
@@ -8,6 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import json
 import os
 

--- a/benchmarking/repo_driver.py
+++ b/benchmarking/repo_driver.py
@@ -8,6 +8,7 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+import argparse
 from collections import deque
 import datetime
 import json
@@ -17,86 +18,88 @@ import threading
 import time
 import traceback
 
-from utils.arg_parse import getParser, getArgs, getUnknowns, parseKnown
+from harness import BenchmarkDriver
 from repos.repos import getRepo
 from utils.build_program import buildProgramPlatform
 from utils.custom_logger import getLogger
 from utils.utilities import getDirectory, getPythonInterpreter, \
     deepMerge, getString, getRunStatus, setRunStatus
 
-getParser().add_argument("--ab_testing", action="store_true",
+parser = argparse.ArgumentParser(description="Perform one benchmark run")
+parser.add_argument("--ab_testing", action="store_true",
     help="Enable A/B testing in benchmark.")
-getParser().add_argument("--base_commit",
+parser.add_argument("--base_commit",
     help="In A/B testing, this is the control commit that is used to compare against. " +
     "If not specified, the default is the first commit in the week in UTC timezone. " +
     "Even if specified, the control is the later of the specified commit and the commit at the start of the week.")
-getParser().add_argument("--branch", default="master",
+parser.add_argument("--branch", default="master",
     help="The remote repository branch. Defaults to master")
-getParser().add_argument("--commit", default="master",
+parser.add_argument("--commit", default="master",
     help="The commit this benchmark runs on. It can be a branch. Defaults to master. " +
     "If it is a commit hash, and program runs on continuous mode, it is the starting " +
     "commit hash the regression runs on. The regression runs on all commits starting from "
     "the specified commit.")
-getParser().add_argument("--commit_file",
+parser.add_argument("--commit_file",
     help="The file saves the last commit hash that the regression has finished. " +
     "If this argument is specified and is valid, the --commit has no use.")
-getParser().add_argument("--env", help="environment variables passed to runtime binary")
-getParser().add_argument("--exec_dir", required=True,
+parser.add_argument("--env", help="environment variables passed to runtime binary")
+parser.add_argument("--exec_dir", required=True,
     help="The executable is saved in the specified directory. " +
     "If an executable is found for a commit, no re-compilation is performed. " +
     "Instead, the previous compiled executable is reused.")
-getParser().add_argument("--framework", required=True,
+parser.add_argument("--framework", required=True,
     choices=["caffe2", "oculus", "generic", "tflite"],
     help="Specify the framework to benchmark on.")
-getParser().add_argument("--frameworks_dir",
+parser.add_argument("--frameworks_dir",
     default=os.path.join(str(os.path.dirname(os.path.realpath(__file__))),
         "..", "specifications", "frameworks"),
     help="Required. The root directory that all frameworks resides. "
     "Usually it is the " + os.path.join("specifications", "frameworks") +
     "directory.")
-getParser().add_argument("--interval", type=int,
+parser.add_argument("--interval", type=int,
     help="The minimum time interval in seconds between two benchmark runs.")
-getParser().add_argument("--platforms", required=True,
+parser.add_argument("--platforms", required=True,
     help="Specify the platforms to benchmark on, in comma separated list."
     "Use this flag if the framework"
     " needs special compilation scripts. The scripts are called build.sh "
     "saved in " + os.path.join("specifications", "frameworks", "<framework>",
     "<platforms>") + " directory")
-getParser().add_argument("--regression", action="store_true",
+parser.add_argument("--regression", action="store_true",
     help="Indicate whether this run detects regression.")
-getParser().add_argument("--remote_repository", default="origin",
+parser.add_argument("--remote_repository", default="origin",
     help="The remote repository. Defaults to origin")
-getParser().add_argument("--repo", default="git",
+parser.add_argument("--repo", default="git",
     choices=["git", "hg"],
     help="Specify the source control repo of the framework.")
-getParser().add_argument("--repo_dir", required=True,
+parser.add_argument("--repo_dir", required=True,
     help="Required. The base framework repo directory used for benchmark.")
-getParser().add_argument("--same_host", action="store_true",
+parser.add_argument("--same_host", action="store_true",
     help="Specify whether the build and benchmark run are on the same host. "
     "If so, the build cannot be done in parallel with the benchmark run.")
-getParser().add_argument("--status_file",
+parser.add_argument("--status_file",
     help="A file to inform the driver stops running when the content of the file is 0.")
-getParser().add_argument("--step", type=int, default=1,
+parser.add_argument("--step", type=int, default=1,
     help="Specify the number of commits we want to run the  benchmark once under continuous mode.")
 
 
-def stopRun():
-    if getArgs().status_file and os.path.isfile(getArgs().status_file):
-        with open(getArgs().status_file, 'r') as file:
+def stopRun(status_file):
+    if status_file and os.path.isfile(status_file):
+        with open(status_file, 'r') as file:
             content = file.read().strip()
             if content == "0":
                 return True
     return False
 
 
-def _runIndividual():
-    return not getArgs().interval and not getArgs().regression and \
-        not getArgs().ab_testing
+def _runIndividual(interval, regression, ab_testing):
+    return not interval and not regression and not ab_testing
 
 
 class ExecutablesBuilder (threading.Thread):
-    def __init__(self, repo, work_queue, queue_lock):
+    def __init__(self, repo, work_queue, queue_lock, **kwargs):
         threading.Thread.__init__(self)
+        raw_args = kwargs.get('raw_args', None)
+        self.args, self.unknowns = parser.parse_known_args(raw_args)
         self.repo = repo
         self.work_queue = work_queue
         self.queue_lock = queue_lock
@@ -104,10 +107,10 @@ class ExecutablesBuilder (threading.Thread):
 
     def run(self):
         try:
-            if getArgs().interval:
-                while not stopRun():
+            if self.args.interval:
+                while not stopRun(self.args.status_file):
                     self._buildExecutables()
-                    time.sleep(getArgs().interval)
+                    time.sleep(self.args.interval)
             else:
                 # single run
                 self._buildExecutables()
@@ -116,15 +119,15 @@ class ExecutablesBuilder (threading.Thread):
             getLogger().error(traceback.format_exc())
 
     def _buildExecutables(self):
-        platforms = getArgs().platforms.split(",")
-        while not stopRun() and self._pullNewCommits():
+        platforms = self.args.platforms.split(",")
+        while not stopRun(self.args.status_file) and self._pullNewCommits():
             for platform in platforms:
                 self._saveOneCommitExecutable(platform)
 
     def _saveOneCommitExecutable(self, platform):
         getLogger().info("Building executable on {} ".format(platform) +
                          "@ {}".format(self.current_commit_hash))
-        same_host = getArgs().same_host
+        same_host = self.args.same_host
         if same_host:
             self.queue_lock.acquire()
         repo_info = self._buildOneCommitExecutable(platform,
@@ -146,11 +149,11 @@ class ExecutablesBuilder (threading.Thread):
             return None
         repo_info['treatment'] = repo_info_treatment
 
-        if getArgs().ab_testing:
+        if self.args.ab_testing:
             # only build control on regression detection
             # figure out the base commit. It is the first commit in the week
             control_commit_hash = self._getControlCommit(
-                repo_info_treatment['commit_time'], getArgs().base_commit)
+                repo_info_treatment['commit_time'], self.args.base_commit)
 
             repo_info_control = self._setupRepoStep(platform,
                                                     control_commit_hash)
@@ -159,14 +162,14 @@ class ExecutablesBuilder (threading.Thread):
             repo_info['control'] = repo_info_control
 
         # Pass meta file from build to benchmark
-        meta_file = os.path.join(getArgs().frameworks_dir, getArgs().framework,
+        meta_file = os.path.join(self.args.frameworks_dir, self.args.framework,
                                  platform, "meta.json")
         if os.path.isfile(meta_file):
             with open(meta_file, "r") as f:
                 meta = json.load(f)
                 repo_info["meta"] = meta
 
-        if getArgs().regression:
+        if self.args.regression:
             repo_info["regression_commits"] = \
                 self._getCompareCommits(repo_info_treatment['commit'])
         # use repo_info to pass the value of platform
@@ -189,23 +192,24 @@ class ExecutablesBuilder (threading.Thread):
 
     def _pullNewCommits(self):
         new_commit_hash = None
-        if _runIndividual():
+        if _runIndividual(self.args.interval, self.args.regression,
+                self.args.ab_testing):
             new_commit_hash = self.repo.getCurrentCommitHash()
             if new_commit_hash is None:
                 getLogger().error("Commit is not specified")
                 return False
         else:
             # first get into the correct branch
-            self.repo.checkout(getArgs().branch)
-            self.repo.pull(getArgs().remote_repository, getArgs().branch)
+            self.repo.checkout(self.args.branch)
+            self.repo.pull(self.args.remote_repository, self.args.branch)
             if self.current_commit_hash is None:
                 self.current_commit_hash = self._getSavedCommit()
 
             if self.current_commit_hash is None:
-                new_commit_hash = self.repo.getCommitHash(getArgs().commit)
+                new_commit_hash = self.repo.getCommitHash(self.args.commit)
             else:
                 new_commit_hash = self.repo.getNextCommitHash(
-                    self.current_commit_hash, getArgs().step)
+                    self.current_commit_hash, self.args.step)
         if new_commit_hash == self.current_commit_hash:
             getLogger().info("Commit %s is already processed, sleeping...",
                              new_commit_hash)
@@ -214,9 +218,9 @@ class ExecutablesBuilder (threading.Thread):
         return True
 
     def _getSavedCommit(self):
-        if getArgs().commit_file and \
-                os.path.isfile(getArgs().commit_file):
-            with open(getArgs().commit_file, 'r') as file:
+        if self.args.commit_file and \
+                os.path.isfile(self.args.commit_file):
+            with open(self.args.commit_file, 'r') as file:
                 commit_hash = file.read().strip()
                 # verify that the commit exists
                 return self.repo.getCommitHash(commit_hash)
@@ -231,12 +235,12 @@ class ExecutablesBuilder (threading.Thread):
 
     def _buildProgram(self, platform, repo_info):
         directory = getDirectory(repo_info['commit'], repo_info['commit_time'])
-        program = getArgs().framework + "_benchmark"
+        program = self.args.framework + "_benchmark"
         if os.name == "nt":
             program = program + ".exe"
         elif platform.startswith("ios"):
             program = program + ".ipa"
-        dst = os.path.join(getArgs().exec_dir, getArgs().framework,
+        dst = os.path.join(self.args.exec_dir, self.args.framework,
                            platform, directory, program)
 
         repo_info["program"] = dst
@@ -246,7 +250,8 @@ class ExecutablesBuilder (threading.Thread):
             }
         }
         filedir = os.path.dirname(dst)
-        if not _runIndividual() and os.path.isfile(dst):
+        if not _runIndividual(self.args.interval, self.args.regression,
+                self.args.ab_testing) and os.path.isfile(dst):
             return True
         else:
             result = self._buildProgramPlatform(repo_info, dst, platform)
@@ -259,9 +264,9 @@ class ExecutablesBuilder (threading.Thread):
 
     def _buildProgramPlatform(self, repo_info, dst, platform):
         self.repo.checkout(repo_info['commit'])
-        return buildProgramPlatform(dst, getArgs().repo_dir,
-                                    getArgs().framework,
-                                    getArgs().frameworks_dir, platform)
+        return buildProgramPlatform(dst, self.args.repo_dir,
+                                    self.args.framework,
+                                    self.args.frameworks_dir, platform)
 
     def _getControlCommit(self, reference_time, base_commit):
         # Get start of week
@@ -300,14 +305,16 @@ class ExecutablesBuilder (threading.Thread):
 
 
 class RepoDriver(object):
-    def __init__(self):
-        parseKnown()
-        self.repo = getRepo()
+    def __init__(self, **kwargs):
+        raw_args = kwargs.get('raw_args', None)
+        self.args, self.unknowns = parser.parse_known_args(raw_args)
+        self.repo = getRepo(repo=self.args.repo, repo_dir=self.args.repo_dir)
         self.queue_lock = threading.Lock()
         self.work_queue = deque()
         self.executables_builder = ExecutablesBuilder(self.repo,
                                                       self.work_queue,
-                                                      self.queue_lock)
+                                                      self.queue_lock,
+                                                      raw_args=raw_args)
 
     def run(self):
         getLogger().info(
@@ -315,14 +322,15 @@ class RepoDriver(object):
             datetime.datetime.now().isoformat(' '))
         self.executables_builder.start()
         self._runBenchmarkSuites()
+        sys.exit(getRunStatus())
 
     def _runBenchmarkSuites(self):
         # initially sleep 10 seconds in case no need to build the binary
         time.sleep(10)
-        if getArgs().interval:
-            while not stopRun():
+        if self.args.interval:
+            while not stopRun(self.args.status_file):
                 self._runBenchmarkSuitesInQueue()
-                time.sleep(getArgs().interval)
+                time.sleep(self.args.interval)
         else:
             # single run
             while self.executables_builder.is_alive():
@@ -330,8 +338,8 @@ class RepoDriver(object):
             self._runBenchmarkSuitesInQueue()
 
     def _runBenchmarkSuitesInQueue(self):
-        same_host = getArgs().same_host
-        while not stopRun() and self.work_queue:
+        same_host = self.args.same_host
+        while not stopRun(self.args.status_file) and self.work_queue:
             # we can do this because this is the only
             # consumer of the work_queue
             self.queue_lock.acquire()
@@ -343,28 +351,30 @@ class RepoDriver(object):
                 self.queue_lock.release()
 
     def _runOneBenchmarkSuite(self, repo_info):
-        cmd = self._getCommand(repo_info)
-        getLogger().info("Running: %s", cmd)
-        if not _runIndividual():
+        raw_args = self._getRawArgs(repo_info)
+        if not _runIndividual(self.args.interval, self.args.regression,
+                self.args.ab_testing):
             # always sleep 10 seconds to make the phone in a more
             # consistent state
-            time.sleep(10)
+            time.sleep(1)
         # cannot use subprocess because it conflicts with requests
-        ret = os.system(cmd)
+        app = BenchmarkDriver(raw_args=raw_args)
+        app.run()
+        ret = 0
         setRunStatus(ret >> 8)
-        if getArgs().commit_file and getArgs().regression:
-            with open(getArgs().commit_file, 'w') as file:
+        if self.args.commit_file and self.args.regression:
+            with open(self.args.commit_file, 'w') as file:
                 file.write(repo_info['treatment']['commit'])
         getLogger().info("One benchmark run {} for ".format(
                          "successful" if ret == 0 else "failed") +
                          repo_info['treatment']['commit'])
 
-    def _getCommand(self, repo_info):
+    def _getRawArgs(self, repo_info):
         platform = repo_info["platform"]
         # Remove it from repo_info to avoid polution, should clean up later
         del repo_info["platform"]
         dir_path = os.path.dirname(os.path.realpath(__file__))
-        unknowns = getUnknowns()
+        unknowns = self.unknowns
         # a not so elegant way of merging info construct
         if '--info' in unknowns:
             info_idx = unknowns.index('--info')
@@ -372,22 +382,20 @@ class RepoDriver(object):
             deepMerge(repo_info, info)
             del unknowns[info_idx+1]
             del unknowns[info_idx]
-        info = getString(json.dumps(repo_info))
-        command = getPythonInterpreter() + " " + \
-            os.path.join(dir_path, "harness.py") + " " + \
-            " --platform " + getString(platform) + \
-            " --framework " + getString(getArgs().framework) + \
-            " --info " + info + " " + \
-            ' '.join([getString(u) for u in unknowns])
-        if getArgs().env:
-            command = command + " --env "
-            env_vars = getArgs().env.split()
+        info = json.dumps(repo_info)
+        raw_args = []
+        raw_args.extend(["--platform", getString(platform),
+                         "--framework", getString(self.args.framework),
+                         "--info", info])
+        raw_args.extend(unknowns)
+        if self.args.env:
+            raw_args.append("--env")
+            env_vars = self.args.env.split()
             for env_var in env_vars:
-                command = command + ' ' + env_var + ' '
-        return command
+                raw_args.append(env_var)
+        return raw_args
 
 
 if __name__ == "__main__":
     app = RepoDriver()
     app.run()
-    sys.exit(getRunStatus())

--- a/benchmarking/repo_driver.py
+++ b/benchmarking/repo_driver.py
@@ -323,7 +323,7 @@ class RepoDriver(object):
     def run(self):
         getLogger().info(
             "Start benchmark run @ %s" %
-            datetime.datetime.now().isoformat(' '))
+            datetime.datetime.now().strftime("%Y_%m_%d_%H_%M"))
         self.executables_builder.start()
         self._runBenchmarkSuites()
         sys.exit(getRunStatus())

--- a/benchmarking/repo_driver.py
+++ b/benchmarking/repo_driver.py
@@ -356,7 +356,7 @@ class RepoDriver(object):
                 self.args.ab_testing):
             # always sleep 10 seconds to make the phone in a more
             # consistent state
-            time.sleep(1)
+            time.sleep(10)
         # cannot use subprocess because it conflicts with requests
         app = BenchmarkDriver(raw_args=raw_args)
         app.run()

--- a/benchmarking/repo_driver.py
+++ b/benchmarking/repo_driver.py
@@ -312,7 +312,7 @@ class RepoDriver(object):
     def __init__(self, **kwargs):
         raw_args = kwargs.get('raw_args', None)
         self.args, self.unknowns = parser.parse_known_args(raw_args)
-        self.repo = getRepo(repo=self.args.repo, repo_dir=self.args.repo_dir)
+        self.repo = getRepo(self.args.repo, self.args.repo_dir)
         self.queue_lock = threading.Lock()
         self.work_queue = deque()
         self.executables_builder = ExecutablesBuilder(self.repo,

--- a/benchmarking/repo_driver.py
+++ b/benchmarking/repo_driver.py
@@ -373,7 +373,6 @@ class RepoDriver(object):
         platform = repo_info["platform"]
         # Remove it from repo_info to avoid polution, should clean up later
         del repo_info["platform"]
-        dir_path = os.path.dirname(os.path.realpath(__file__))
         unknowns = self.unknowns
         # a not so elegant way of merging info construct
         if '--info' in unknowns:

--- a/benchmarking/repo_driver.py
+++ b/benchmarking/repo_driver.py
@@ -8,6 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import argparse
 from collections import deque
 import datetime

--- a/benchmarking/reporters/local_reporter/local_reporter.py
+++ b/benchmarking/reporters/local_reporter/local_reporter.py
@@ -8,12 +8,16 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+import json
+import os
+
 from reporters.reporter_base import ReporterBase
 from utils.custom_logger import getLogger
 from utils.utilities import getDirectory, getFilename
-
-import json
-import os
 
 
 class LocalReporter(ReporterBase):

--- a/benchmarking/reporters/local_reporter/local_reporter.py
+++ b/benchmarking/reporters/local_reporter/local_reporter.py
@@ -21,8 +21,8 @@ from utils.utilities import getDirectory, getFilename
 
 
 class LocalReporter(ReporterBase):
-    def __init__(self, **kwargs):
-        self.local_reporter = kwargs.get("local_reporter")
+    def __init__(self, local_reporter):
+        self.local_reporter = local_reporter
         super(LocalReporter, self).__init__()
 
     def report(self, content):

--- a/benchmarking/reporters/local_reporter/local_reporter.py
+++ b/benchmarking/reporters/local_reporter/local_reporter.py
@@ -9,7 +9,6 @@
 ##############################################################################
 
 from reporters.reporter_base import ReporterBase
-from utils.arg_parse import getArgs
 from utils.custom_logger import getLogger
 from utils.utilities import getDirectory, getFilename
 
@@ -18,7 +17,8 @@ import os
 
 
 class LocalReporter(ReporterBase):
-    def __init__(self):
+    def __init__(self, **kwargs):
+        self.local_reporter = kwargs.get("local_reporter")
         super(LocalReporter, self).__init__()
 
     def report(self, content):
@@ -39,7 +39,7 @@ class LocalReporter(ReporterBase):
         ts = float(meta['commit_time'])
         commit = meta['commit']
         datedir = getDirectory(commit, ts)
-        dirname = os.path.join(getArgs().local_reporter, platformdir,
+        dirname = os.path.join(self.local_reporter, platformdir,
                                frameworkdir, netdir, metric_dir,
                                id_dir, datedir)
         i = 0

--- a/benchmarking/reporters/remote_reporter/remote_reporter.py
+++ b/benchmarking/reporters/remote_reporter/remote_reporter.py
@@ -138,9 +138,7 @@ class RemoteReporter(ReporterBase):
             result[count_key] == num_logs
         if not is_good:
             getLogger().error("Submit data to remote server failed")
-            if not request.ok:
-                getLogger().error("Request is not okay")
-            elif count_key not in result:
+            if count_key not in result:
                 getLogger().error(
                     "%s is not in request return value", count_key)
             else:

--- a/benchmarking/reporters/remote_reporter/remote_reporter.py
+++ b/benchmarking/reporters/remote_reporter/remote_reporter.py
@@ -20,9 +20,9 @@ from utils.utilities import requestsJson
 
 
 class RemoteReporter(ReporterBase):
-    def __init__(self, **kwargs):
-        self.remote_reporter = kwargs.get("remote_reporter", None)
-        self.remote_access_token = kwargs.get("remote_access_token")
+    def __init__(self, remote_reporter, remote_access_token):
+        self.remote_reporter = remote_reporter
+        self.remote_access_token = remote_access_token
         super(RemoteReporter, self).__init__()
 
     def report(self, content):

--- a/benchmarking/reporters/remote_reporter/remote_reporter.py
+++ b/benchmarking/reporters/remote_reporter/remote_reporter.py
@@ -8,11 +8,15 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+import json
+
 from reporters.reporter_base import ReporterBase
 from utils.custom_logger import getLogger
 from utils.utilities import requestsJson
-
-import json
 
 
 class RemoteReporter(ReporterBase):

--- a/benchmarking/reporters/remote_reporter/remote_reporter.py
+++ b/benchmarking/reporters/remote_reporter/remote_reporter.py
@@ -9,7 +9,6 @@
 ##############################################################################
 
 from reporters.reporter_base import ReporterBase
-from utils.arg_parse import getArgs
 from utils.custom_logger import getLogger
 from utils.utilities import requestsJson
 
@@ -17,13 +16,15 @@ import json
 
 
 class RemoteReporter(ReporterBase):
-    def __init__(self):
+    def __init__(self, **kwargs):
+        self.remote_reporter = kwargs.get("remote_reporter", None)
+        self.remote_access_token = kwargs.get("remote_access_token")
         super(RemoteReporter, self).__init__()
 
     def report(self, content):
-        if not getArgs().remote_reporter:
+        if not self.remote_reporter:
             return
-        access_token = getArgs().remote_access_token
+        access_token = self.remote_access_token
         remote = self._getRemoteInfo()
         logs = self._composeMessages(content, remote['category'])
 
@@ -40,7 +41,7 @@ class RemoteReporter(ReporterBase):
         return result
 
     def _getRemoteInfo(self):
-        endpoint = getArgs().remote_reporter.strip().split("|")
+        endpoint = self.remote_reporter.strip().split("|")
         assert len(endpoint) == 2, "Category not speied in remote endpoint"
         res = {}
         res['url'] = endpoint[0].strip()

--- a/benchmarking/reporters/reporter_base.py
+++ b/benchmarking/reporters/reporter_base.py
@@ -8,6 +8,11 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 
 class ReporterBase(object):
     DATA = 'data'

--- a/benchmarking/reporters/reporters.py
+++ b/benchmarking/reporters/reporters.py
@@ -8,6 +8,11 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from .local_reporter.local_reporter import LocalReporter
 from .remote_reporter.remote_reporter import RemoteReporter
 from .simple_local_reporter.simple_local_reporter import SimpleLocalReporter

--- a/benchmarking/reporters/reporters.py
+++ b/benchmarking/reporters/reporters.py
@@ -23,12 +23,12 @@ from .simple_screen_reporter.simple_screen_reporter import SimpleScreenReporter
 def getReporters(args):
     reporters = []
     if args.local_reporter:
-        reporters.append(LocalReporter(local_reporter=args.local_reporter))
+        reporters.append(LocalReporter(args.local_reporter))
     if args.simple_local_reporter:
         reporters.append(SimpleLocalReporter(args.simple_local_reporter))
     if args.remote_reporter:
-        reporters.append(RemoteReporter(remote_reporter=args.remote_reporter,
-                                        remote_access_token=args.remote_access_token))
+        reporters.append(RemoteReporter(args.remote_reporter,
+                                        args.remote_access_token))
     if args.screen_reporter:
         reporters.append(ScreenReporter())
     if args.simple_screen_reporter:

--- a/benchmarking/reporters/reporters.py
+++ b/benchmarking/reporters/reporters.py
@@ -8,7 +8,6 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
-from utils.arg_parse import getArgs
 from .local_reporter.local_reporter import LocalReporter
 from .remote_reporter.remote_reporter import RemoteReporter
 from .simple_local_reporter.simple_local_reporter import SimpleLocalReporter
@@ -16,16 +15,17 @@ from .screen_reporter.screen_reporter import ScreenReporter
 from .simple_screen_reporter.simple_screen_reporter import SimpleScreenReporter
 
 
-def getReporters():
+def getReporters(args):
     reporters = []
-    if getArgs().local_reporter:
-        reporters.append(LocalReporter())
-    if getArgs().simple_local_reporter:
-        reporters.append(SimpleLocalReporter())
-    if getArgs().remote_reporter:
-        reporters.append(RemoteReporter())
-    if getArgs().screen_reporter:
+    if args.local_reporter:
+        reporters.append(LocalReporter(local_reporter=args.local_reporter))
+    if args.simple_local_reporter:
+        reporters.append(SimpleLocalReporter(args.simple_local_reporter))
+    if args.remote_reporter:
+        reporters.append(RemoteReporter(remote_reporter=args.remote_reporter,
+                                        remote_access_token=args.remote_access_token))
+    if args.screen_reporter:
         reporters.append(ScreenReporter())
-    if getArgs().simple_screen_reporter:
+    if args.simple_screen_reporter:
         reporters.append(SimpleScreenReporter())
     return reporters

--- a/benchmarking/reporters/screen_reporter/screen_reporter.py
+++ b/benchmarking/reporters/screen_reporter/screen_reporter.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-import cocy
+import copy
 import datetime
 
 from reporters.reporter_base import ReporterBase

--- a/benchmarking/reporters/screen_reporter/screen_reporter.py
+++ b/benchmarking/reporters/screen_reporter/screen_reporter.py
@@ -8,11 +8,16 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+import cocy
+import datetime
+
 from reporters.reporter_base import ReporterBase
 from utils.custom_logger import getLogger
 
-import copy
-import datetime
 
 class ScreenReporter(ReporterBase):
     def __init__(self):

--- a/benchmarking/reporters/simple_local_reporter/simple_local_reporter.py
+++ b/benchmarking/reporters/simple_local_reporter/simple_local_reporter.py
@@ -9,7 +9,6 @@
 ##############################################################################
 
 from reporters.reporter_base import ReporterBase
-from utils.arg_parse import getArgs
 from utils.custom_logger import getLogger
 from utils.utilities import getFilename
 
@@ -20,7 +19,7 @@ import tempfile
 
 
 class SimpleLocalReporter(ReporterBase):
-    def __init__(self):
+    def __init__(self, simple_local_reporter):
         super(SimpleLocalReporter, self).__init__()
 
     def report(self, content):
@@ -33,9 +32,9 @@ class SimpleLocalReporter(ReporterBase):
         dirname = None
         if "identifier" in meta:
             id_dir = getFilename(meta["identifier"])
-            dirname = os.path.join(getArgs().simple_local_reporter, id_dir)
+            dirname = os.path.join(simple_local_reporter, id_dir)
         else:
-            dirname = tempfile.mkdtemp(dir=getArgs().simple_local_reporter)
+            dirname = tempfile.mkdtemp(dir=simple_local_reporter)
 
         if os.path.exists(dirname):
             shutil.rmtree(dirname, True)

--- a/benchmarking/reporters/simple_local_reporter/simple_local_reporter.py
+++ b/benchmarking/reporters/simple_local_reporter/simple_local_reporter.py
@@ -8,14 +8,18 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
-from reporters.reporter_base import ReporterBase
-from utils.custom_logger import getLogger
-from utils.utilities import getFilename
-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import json
 import os
 import shutil
 import tempfile
+
+from reporters.reporter_base import ReporterBase
+from utils.custom_logger import getLogger
+from utils.utilities import getFilename
 
 
 class SimpleLocalReporter(ReporterBase):

--- a/benchmarking/reporters/simple_local_reporter/simple_local_reporter.py
+++ b/benchmarking/reporters/simple_local_reporter/simple_local_reporter.py
@@ -20,6 +20,7 @@ import tempfile
 
 class SimpleLocalReporter(ReporterBase):
     def __init__(self, simple_local_reporter):
+        self.simple_local_reporter = simple_local_reporter
         super(SimpleLocalReporter, self).__init__()
 
     def report(self, content):
@@ -32,9 +33,9 @@ class SimpleLocalReporter(ReporterBase):
         dirname = None
         if "identifier" in meta:
             id_dir = getFilename(meta["identifier"])
-            dirname = os.path.join(simple_local_reporter, id_dir)
+            dirname = os.path.join(self.simple_local_reporter, id_dir)
         else:
-            dirname = tempfile.mkdtemp(dir=simple_local_reporter)
+            dirname = tempfile.mkdtemp(dir=self.simple_local_reporter)
 
         if os.path.exists(dirname):
             shutil.rmtree(dirname, True)

--- a/benchmarking/reporters/simple_screen_reporter/simple_screen_reporter.py
+++ b/benchmarking/reporters/simple_screen_reporter/simple_screen_reporter.py
@@ -8,6 +8,11 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 from reporters.reporter_base import ReporterBase
 
 

--- a/benchmarking/repos/repos.py
+++ b/benchmarking/repos/repos.py
@@ -10,12 +10,9 @@
 
 from .git import GitRepo
 from .hg import HGRepo
-from utils.arg_parse import getArgs
 
 
-def getRepo():
-    repo = getArgs().repo
-    repo_dir = getArgs().repo_dir
+def getRepo(repo, repo_dir):
     if repo == 'git':
         return GitRepo(repo_dir)
     elif repo == 'hg':

--- a/benchmarking/run_bench.py
+++ b/benchmarking/run_bench.py
@@ -8,6 +8,7 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import, division, print_function, unicode_literals
 import argparse
 import copy
 import json

--- a/benchmarking/run_bench.py
+++ b/benchmarking/run_bench.py
@@ -8,7 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import argparse
 import copy
 import json

--- a/benchmarking/run_bench.py
+++ b/benchmarking/run_bench.py
@@ -18,6 +18,7 @@ import json
 import os
 import six
 import sys
+
 from repo_driver import RepoDriver
 from utils.custom_logger import getLogger
 from utils.utilities import getPythonInterpreter, getString, \

--- a/benchmarking/utils/monsoon_power.py
+++ b/benchmarking/utils/monsoon_power.py
@@ -16,11 +16,10 @@ from time import sleep
 import Monsoon.HVPM as HVPM
 import Monsoon.sampleEngine as sampleEngine
 from utils.custom_logger import getLogger
-from utils.arg_parse import getArgs
 
 
-def collectPowerData(hash, sample_time, voltage, num_iters):
-    serialno = _getSerialno(hash)
+def collectPowerData(hash, sample_time, voltage, num_iters, monsoon_map=None):
+    serialno = _getSerialno(hash, monsoon_map)
     if serialno is not None:
         getLogger().info("Collecting current from "
                          "monsoon {} for {}".format(str(serialno), hash))
@@ -226,10 +225,10 @@ def _composeStructuredData(data, metric, unit):
     }
 
 
-def _getSerialno(hash):
+def _getSerialno(hash, monsoon_map=None):
     serialno = None
-    if getArgs().monsoon_map:
-        map = json.loads(getArgs().monsoon_map)
+    if monsoon_map:
+        map = json.loads(monsoon_map)
         if hash in map:
             serialno = map[hash]
     return serialno

--- a/benchmarking/utils/utilities.py
+++ b/benchmarking/utils/utilities.py
@@ -85,7 +85,7 @@ def getString(s):
         # escape " with \"
         return '"' + s.replace('"', '\\"') + '"'
     else:
-        return "'" + s + "'"
+        return s
 
 
 def getFAIPEPROOT():

--- a/benchmarking/utils/utilities.py
+++ b/benchmarking/utils/utilities.py
@@ -79,9 +79,7 @@ def deepReplace(root, pattern, replacement):
 
 def getString(s):
     s = str(s)
-    if re.match("^[A-Za-z0-9_/.~-]+$", s):
-        return s
-    elif os.name == "nt":
+    if os.name == "nt":
         # escape " with \"
         return '"' + s.replace('"', '\\"') + '"'
     else:

--- a/libraries/python/aggregate_classification_results.py
+++ b/libraries/python/aggregate_classification_results.py
@@ -11,6 +11,10 @@
 # This script aggregates test results from multiple runs and form
 # the final result
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import argparse
 import json
 import os

--- a/libraries/python/classification_compare.py
+++ b/libraries/python/classification_compare.py
@@ -12,7 +12,10 @@
 # for image classification tasks, if the golden is 1, expecting the benchmark
 # is the closest to that.
 
-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import argparse
 import json
 import numpy as np

--- a/libraries/python/coco/generate_im_info.py
+++ b/libraries/python/coco/generate_im_info.py
@@ -10,8 +10,10 @@
 
 # This is the script to generate the im_info blob used in MaskRCNN2Go model
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import argparse
 import json
 import logging

--- a/libraries/python/coco/json_dataset.py
+++ b/libraries/python/coco/json_dataset.py
@@ -10,8 +10,10 @@
 
 # This is the library to load the coco dataset
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import argparse
 import copy
 import json

--- a/libraries/python/coco/json_dataset_evaluator.py
+++ b/libraries/python/coco/json_dataset_evaluator.py
@@ -19,7 +19,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-
 import json
 import logging
 import numpy as np

--- a/libraries/python/coco/process_single_image_output.py
+++ b/libraries/python/coco/process_single_image_output.py
@@ -8,6 +8,11 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import argparse
 import cv2
 import json

--- a/libraries/python/coco/process_single_image_output.py
+++ b/libraries/python/coco/process_single_image_output.py
@@ -12,7 +12,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-
 import argparse
 import cv2
 import json

--- a/libraries/python/coco/test_engine.py
+++ b/libraries/python/coco/test_engine.py
@@ -8,6 +8,10 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import argparse
 import logging
 import numpy as np

--- a/libraries/python/imagenet_test_map.py
+++ b/libraries/python/imagenet_test_map.py
@@ -12,6 +12,10 @@
 # when the images and labels are saved in the imagenet dataset hierarchy.
 # Optionally the images are shuffled
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import argparse
 import random
 import os

--- a/libraries/python/onnx_to_caffe2.py
+++ b/libraries/python/onnx_to_caffe2.py
@@ -8,6 +8,12 @@
 # LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+import argparse
+
 import onnx
 from caffe2.python.onnx.backend import Caffe2Backend
 

--- a/libraries/python/onnx_to_caffe2.py
+++ b/libraries/python/onnx_to_caffe2.py
@@ -17,8 +17,6 @@ import argparse
 import onnx
 from caffe2.python.onnx.backend import Caffe2Backend
 
-import argparse
-
 
 parser = argparse.ArgumentParser(description="Convert ONNX models "
     "to Caffe2 models")


### PR DESCRIPTION
This diff changes:

(1) the parser style such that args will passed by module attributes instead of calling getArgs.
(2) move the status into class module instead of main function
(3) lint
(4) run_bench will call repo_driver by creating class instance, also repo_driver call harness

Test Plan:
For OSS side, I tested the code locally via 
```
$ ./benchmarking/run_bench.py -b specifications/models/caffe2/squeezenet/squeezenet.json
$ ./benchmarking/run_bench.py -b specifications/models/caffe2/squeezenet/squeezenet.json --platform host
```