### PR TITLE
overwrite status

### DIFF
--- a/benchmarking/platforms/android/android_platform.py
+++ b/benchmarking/platforms/android/android_platform.py
@@ -49,7 +49,11 @@ class AndroidPlatform(PlatformBase):
         size = 131072
         while (repeat and size > 256):
             repeat = False
+            # We know this command may fail. Avoid propogating this
+            # failure to the upstream
+            success = getRunStatus()
             ret = self.util.logcat("-G", str(size) + "K")
+            setRunStatus(success, overwrite=True)
             if len(ret) > 0 and ret[0].find("failed to") >= 0:
                 repeat = True
                 size = int(size / 2)
@@ -105,7 +109,11 @@ class AndroidPlatform(PlatformBase):
     def runBenchmark(self, cmd, *args, **kwargs):
         if not isinstance(cmd, list):
             cmd = shlex.split(cmd)
+        # We know this command may fail. Avoid propogating this
+        # failure to the upstream
+        success = getRunStatus()
         self.util.logcat('-b', 'all', '-c')
+        setRunStatus(success, overwrite=True)
         if self.app:
             log = self.runAppBenchmark(cmd, *args, **kwargs)
         else:


### PR DESCRIPTION
Summary:
for some devices (like Moto G5), we will see the following error P61010413.
```
huaminli at huaminli-mbp in ~/fbsource/xplat
$ adb -s ZY322M4973 logcat -b all -c
- waiting for device -
failed to clear the 'security' log
huaminli at huaminli-mbp in ~/fbsource/xplat
$ adb -s ZY322M4973 logcat -G 131072K
failed to set the 'main' log size
```
Those failures will set status to 1. However, we can still get the result back. So we will set status to 0 whenever we capture this.

Differential Revision: D14270226
