### PR TITLE
Add a path for the binary destination to the oculus framework

### DIFF
--- a/benchmarking/frameworks/oculus/oculus.py
+++ b/benchmarking/frameworks/oculus/oculus.py
@@ -61,7 +61,9 @@ class OculusFramework(FrameworkBase):
         outputs = [os.path.join(platform.getOutputDir(), t["filename"])
                    for t in test["output_files"]]
         # Always copy binary to /system/bin/ directory
-        program = platform.copyFilesToPlatform(info["programs"]["program"]["location"], "/system/bin/")
+        program = platform.copyFilesToPlatform(
+                info["programs"]["program"]["location"],
+                info["programs"]["program"]["dest_path"])
         commands = self._composeRunCommand(program, platform, test,
                                            inputs, outputs)
         platform.runBenchmark(commands, log_to_screen_only=True)


### PR DESCRIPTION
Summary: We have some devices for which /system/bin/ isn't the best
place to keep the binary under test. It's easy enough to modify the
commandline we run to specify this.