### PR TITLE
Add bench mark result table to OSS as remote reporter

### DIFF
--- a/ailab/benchmark/benchmark_result_controller.py
+++ b/ailab/benchmark/benchmark_result_controller.py
@@ -1,0 +1,46 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import json
+
+from .models import BenchmarkResult
+
+
+def store_result(data):
+    logs = json.loads(data['logs'])
+
+    for log in logs:
+        store_single_entry(log)
+
+    return {"status": "success"}
+
+
+def store_single_entry(log):
+    message = json.loads(log['message'])
+
+    r = BenchmarkResult()
+
+    process_entry(r, message, 'int')
+    process_entry(r, message, 'normal')
+    process_vec_entry(r, message, 'normvector')
+
+    r.save()
+
+
+def process_entry(r, message, type):
+    for k, v in message[type].items():
+        if k == 'net_name':
+            k = 'model'
+        try:
+            setattr(r, k, v)
+        except Exception:
+            print("{} is not a valid field")
+
+def process_vec_entry(r, message, type):
+    for k, v in message[type].items():
+        if k == 'net_name':
+            k = 'model'
+        v = json.dumps(v)
+        try:
+            setattr(r, k, v)
+        except Exception:
+            print("{} is not a valid field")

--- a/ailab/benchmark/models.py
+++ b/ailab/benchmark/models.py
@@ -65,3 +65,68 @@ class Device(models.Model):
             models.Index(fields=['claimer']),
             models.Index(fields=['job_queue']),
         ]
+
+
+class BenchmarkResult(models.Model):
+    # Count
+    num_runs = models.BigIntegerField(null=True)
+    time = models.BigIntegerField(null=True)
+
+    control_commit_time = models.BigIntegerField(null=True)
+    commit_time = models.BigIntegerField(null=True)
+
+    control_stdev = models.BigIntegerField(null=True)
+    stdev = models.BigIntegerField(null=True)
+
+    control_mean = models.BigIntegerField(null=True)
+    mean = models.BigIntegerField(null=True)
+    diff_mean = models.BigIntegerField(null=True)
+
+    control_p0 = models.BigIntegerField(null=True)
+    p0 = models.BigIntegerField(null=True)
+    diff_p0 = models.BigIntegerField(null=True)
+
+    control_p10 = models.BigIntegerField(null=True)
+    p10 = models.BigIntegerField(null=True)
+    diff_p10 = models.BigIntegerField(null=True)
+
+    control_p50 = models.BigIntegerField(null=True)
+    p50 = models.BigIntegerField(null=True)
+    diff_p50 = models.BigIntegerField(null=True)
+
+    control_p90 = models.BigIntegerField(null=True)
+    p90 = models.BigIntegerField(null=True)
+    diff_p90 = models.BigIntegerField(null=True)
+
+    control_p100 = models.BigIntegerField(null=True)
+    p100 = models.BigIntegerField(null=True)
+    diff_p100 = models.BigIntegerField(null=True)
+
+    control_p95 = models.BigIntegerField(null=True)
+    p95 = models.BigIntegerField(null=True)
+
+    control_p99 = models.BigIntegerField(null=True)
+    p99 = models.BigIntegerField(null=True)
+
+    # Normals
+    control_commit = models.TextField(null=True)
+    commit = models.TextField(null=True)
+
+    backend = models.TextField(null=True)
+    command = models.TextField(null=True)
+    framework = models.TextField(null=True)
+    group = models.TextField(null=True)
+    identifier = models.TextField(null=True)
+    info_string = models.TextField(null=True)
+    metric = models.TextField(null=True)
+    model = models.TextField(null=True)
+    platform = models.TextField(null=True)
+    platform_hash = models.TextField(null=True)
+    type = models.TextField(null=True)
+    unit = models.TextField(null=True)
+    user = models.TextField(null=True)
+    user_identifier = models.TextField(null=True)
+
+    # Normal Vectors
+    control_values = models.TextField(null=True)  # JSON-serialized list
+    values = models.TextField(null=True)  # JSON-serialized list

--- a/ailab/benchmark/urls.py
+++ b/ailab/benchmark/urls.py
@@ -5,4 +5,5 @@ from . import views
 
 urlpatterns = [
     url(r'^$', views.handle_request, name='index'),
+    url(r'^store-result$', views.store_benchmark_result, name='store_benchmark_result'),
 ]

--- a/ailab/benchmark/views.py
+++ b/ailab/benchmark/views.py
@@ -1,15 +1,26 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import json
+
 from django.http import JsonResponse
 
 from django.views.decorators.csrf import csrf_exempt
 import db_controller
+import benchmark_result_controller
 
 
 @csrf_exempt
 def handle_request(request):
     data = request.POST.copy()
     results = db_controller.get_payload(data)
+
+    return JsonResponse(results)
+
+
+@csrf_exempt
+def store_benchmark_result(request):
+    data = json.loads(request.body)
+    results = benchmark_result_controller.store_result(data)
 
     return JsonResponse(results)


### PR DESCRIPTION
Summary: This diff creates benchmark result table and its corresponding handler in OSS and allow remote reporter to use.

Reviewed By: sf-wind

Differential Revision: D14425510
