### PR TITLE
fetch_result and fetch_status return result instead of just print

### DIFF
--- a/benchmarking/lab_driver.py
+++ b/benchmarking/lab_driver.py
@@ -128,7 +128,9 @@ class LabDriver(object):
         raw_args.extend(self.unknowns)
         getLogger().info("Running {} with raw_args {}".format(app_class, raw_args))
         app = app_class(raw_args=raw_args)
-        app.run()
+        res = app.run()
+        if res:
+            return res
 
 
 if __name__ == "__main__":

--- a/benchmarking/run_bench.py
+++ b/benchmarking/run_bench.py
@@ -47,6 +47,8 @@ class RunBench(object):
         raw_args = self._getRawArgs()
         app = self.repoCls(raw_args=raw_args)
         ret = app.run()
+        if ret and json.loads(ret):
+            return ret
         if ret is not None:
             setRunStatus(ret >> 8)
         sys.exit(getRunStatus())

--- a/benchmarking/run_remote.py
+++ b/benchmarking/run_remote.py
@@ -197,8 +197,8 @@ class RunRemote(object):
             self._printJobQueues()
             return
         if self.args.fetch_status or self.args.fetch_result:
-            self._fetchResult()
-            return
+            result = self._fetchResult()
+            return result
 
         assert self.args.benchmark_file, \
             "--benchmark_file (-b) must be specified"
@@ -447,13 +447,16 @@ class RunRemote(object):
         assert user_identifier, "User identifier must be specified for " \
             "fetching the status and/or result of the previously run benchmarks"
         statuses = self.db.statusBenchmarks(user_identifier)
+        result = None
         if self.args.fetch_status:
-            print(json.dumps(statuses))
+            result = json.dumps(statuses)
         elif self.args.fetch_result:
             ids = ",".join([str(status["id"]) for status in statuses])
             output = self.db.getBenchmarks(ids)
             self._mobilelabResult(output)
-            print(json.dumps(output))
+            result = json.dumps(output)
+        print(result)
+        return result
 
     def _mobilelabResult(self, output):
         # always get the last result


### PR DESCRIPTION
Summary: as title. As we are changing the code in fbcode to use module call instead of script run, we want to return the result from `fecth_result` and `fetch_status` besides just print the result to screen.

Differential Revision: D14530025
