### PR TITLE
change default logger level to info

### DIFF
--- a/benchmarking/lab_driver.py
+++ b/benchmarking/lab_driver.py
@@ -28,7 +28,7 @@ parser.add_argument("-b", "--benchmark_file",
     help="Specify the json file for the benchmark or a number of benchmarks")
 parser.add_argument("--lab", action="store_true",
     help="Indicate whether the run is lab run.")
-parser.add_argument("--logger_level", default="warning",
+parser.add_argument("--logger_level", default="info",
     choices=["info", "warning", "error"],
     help="Specify the logger level")
 parser.add_argument("--remote", action="store_true",

--- a/benchmarking/run_bench.py
+++ b/benchmarking/run_bench.py
@@ -29,7 +29,7 @@ parser = argparse.ArgumentParser(description="Perform one benchmark run")
 parser.add_argument("--config_dir",
     default=os.path.join(HOME_DIR, ".aibench", "git"),
     help="Specify the config root directory.")
-parser.add_argument("--logger_level", default="warning",
+parser.add_argument("--logger_level", default="info",
     choices=["info", "warning", "error"],
     help="Specify the logger level")
 parser.add_argument("--reset_options", action="store_true",

--- a/benchmarking/run_remote.py
+++ b/benchmarking/run_remote.py
@@ -76,7 +76,7 @@ parser.add_argument("--list_devices", action="store_true",
     help="List the devices associated to the job queue")
 parser.add_argument("--list_job_queues", action="store_true",
     help="List the job queues that have available devices")
-parser.add_argument("--logger_level", default="warning",
+parser.add_argument("--logger_level", default="info",
     choices=["info", "warning", "error"],
     help="Specify the logger level")
 parser.add_argument("--string_map",


### PR DESCRIPTION
Summary: As title, we want to change the default logger_level to `info`. Then there is no need to add the parser `--logger_level info` everytime.

Differential Revision: D14647310
