### PR TITLE
change number of processes depends on the use case

### DIFF
--- a/benchmarking/run_lab.py
+++ b/benchmarking/run_lab.py
@@ -335,8 +335,11 @@ class RunLab(object):
         dvs = [self.devices[k][h] for k in self.devices for h in self.devices[k]]
         self.db.updateDevices(self.args.claimer_id,
                                getDevicesString(dvs), True)
-        self.pool = multiprocessing.Pool(
-            processes=multiprocessing.cpu_count() - 1 or 1)
+        if self.args.platform.startswith("host"):
+            numProcesses = 2
+        else:
+            numProcesses = multiprocessing.cpu_count() - 1
+        self.pool = multiprocessing.Pool(processes=numProcesses)
 
     def run(self):
         while(not stopRun(self.args)):


### PR DESCRIPTION
Summary: as title. For android lab, it is ok to have many processes. For host lab, it is better to have only 1 or 2 process.

Reviewed By: llyfacebook

Differential Revision: D14575197
