### PR TITLE
Make error message clear when neither server_addr nor benchmark_db_entry is specified

### DIFF
--- a/benchmarking/run_lab.py
+++ b/benchmarking/run_lab.py
@@ -302,6 +302,8 @@ class RunLab(object):
         devices = self._getDevices()
         setLoggerLevel(self.args.logger_level)
         if not self.args.benchmark_db_entry:
+            assert self.args.server_addr is not None, \
+                "Either server_addr or benchmark_db_entry must be specified"
             self.args.benchmark_db_entry = self.args.server_addr + "benchmark/"
         self.db = DBDriver(self.args.benchmark_db,
                            self.args.app_id,

--- a/benchmarking/run_remote.py
+++ b/benchmarking/run_remote.py
@@ -176,6 +176,8 @@ class RunRemote(object):
         self.args, self.unknowns = parser.parse_known_args(raw_args)
         setLoggerLevel(self.args.logger_level)
         if not self.args.benchmark_db_entry:
+            assert self.args.server_addr is not None, \
+                "Either server_addr or benchmark_db_entry must be specified"
             self.args.benchmark_db_entry = self.args.server_addr + "benchmark/"
         self.db = DBDriver(self.args.benchmark_db,
                            self.args.app_id,


### PR DESCRIPTION
Summary: When neither `server_addr` nor `benchmark_db_entry` is specified, the error message was previously not clear about what went wrong.

Reviewed By: sf-wind

Differential Revision: D14818014
