### PR TITLE
add query_num_devices into run_remote parser

### DIFF
--- a/benchmarking/run_bench.py
+++ b/benchmarking/run_bench.py
@@ -47,7 +47,9 @@ class RunBench(object):
         raw_args = self._getRawArgs()
         app = self.repoCls(raw_args=raw_args)
         ret = app.run()
-        if ret and json.loads(ret):
+        if "--query_num_devices" in self.unknowns:
+            return ret
+        if "--fetch_status" in self.unknowns or "--fetch_result" in self.unknowns:
             return ret
         if ret is not None:
             setRunStatus(ret >> 8)


### PR DESCRIPTION
Summary: This diff will add a new parser `query_num_devices` to run_remote and it will return a python dictionary that is actually a Counter for user's specified device under different condition.

Differential Revision: D14835866
