### PR TITLE
provide aibench UI URL at the end of remote run

### DIFF
--- a/benchmarking/remote/screen_reporter.py
+++ b/benchmarking/remote/screen_reporter.py
@@ -22,12 +22,15 @@ class ScreenReporter(object):
         self.devices = devices
         self.debug = debug
 
-    def run(self, user_identifier):
+    def run(self, user_identifier, urlPrefix=None):
         done = False
         statuses = {}
         while not done:
             done = self._runOnce(user_identifier, statuses)
             time.sleep(1)
+        if urlPrefix:
+            print("You can find more info via {}{}".format(
+                urlPrefix, user_identifier))
 
     def _runOnce(self, user_identifier, statuses):
         new_statuses = self.xdb.statusBenchmarks(user_identifier)

--- a/benchmarking/run_remote.py
+++ b/benchmarking/run_remote.py
@@ -118,6 +118,8 @@ parser.add_argument("--test", action="store_true",
 parser.add_argument("--token",
     help="The token you use to upload/download your file for everstore "
     "and access the job queue")
+parser.add_argument("--urlPrefix",
+    help="URL Prefix if you want to find your result from the URL.")
 parser.add_argument("--user_identifier",
     help="The identifier user pass in to differentiate different benchmark runs.")
 parser.add_argument("--user_string",
@@ -468,7 +470,7 @@ class RunRemote(object):
 
     def _screenReporter(self, user_identifier):
         reporter = ScreenReporter(self.db, self.devices, self.args.debug)
-        reporter.run(user_identifier)
+        reporter.run(user_identifier, self.args.urlPrefix)
 
     def _fetchResult(self):
         user_identifier = self.args.user_identifier


### PR DESCRIPTION
Summary: provide aibench UI URL at the end of remote run

Differential Revision: D15024659

