### PR TITLE
Provide default filter value when no parameter is present

### DIFF
--- a/ailab/benchmark/views.py
+++ b/ailab/benchmark/views.py
@@ -73,6 +73,11 @@ def visualize(request):
         qs = BenchmarkResult.objects.filter(result_q)
     else:
         qs = BenchmarkResult.objects.all()
+        filters = {
+            'condition': 'AND',
+            'rules': [{}],
+        }
+        print(filters)
 
     # Build table with specified columns
     table = ResultTable(qs)

--- a/ailab/benchmark/views.py
+++ b/ailab/benchmark/views.py
@@ -77,7 +77,6 @@ def visualize(request):
             'condition': 'AND',
             'rules': [{}],
         }
-        print(filters)
 
     # Build table with specified columns
     table = ResultTable(qs)


### PR DESCRIPTION


Previously, the filter component is crashed when no filter parameter is presented in the URL. By applying this fix, a QueryBuilder object is properly presented.

Test Plans:
After running the server, go to http://127.0.0.1:8000/benchmark/visualize and check the filter tab.
![faipep test filter](https://user-images.githubusercontent.com/17319633/57000938-d8d42d00-6b6a-11e9-85ca-7e353878c735.png)