### PR TITLE
For the oculus framework, allow passing environment variables in

### DIFF
--- a/benchmarking/frameworks/oculus/oculus.py
+++ b/benchmarking/frameworks/oculus/oculus.py
@@ -64,7 +64,8 @@ class OculusFramework(FrameworkBase):
         program = platform.copyFilesToPlatform(
                 info["programs"]["program"]["location"],
                 info["programs"]["program"]["dest_path"])
-        commands = self._composeRunCommand(program, platform, test,
+        env_vars = info["programs"]["program"].get("env_variables", "")
+        commands = self._composeRunCommand(env_vars, program, platform, test,
                                            inputs, outputs)
         platform.runBenchmark(commands, log_to_screen_only=True)
 
@@ -139,9 +140,9 @@ class OculusFramework(FrameworkBase):
             assert "metric" in test, \
                 "metric must exist in test in benchmark {}".format(filename)
 
-    def _composeRunCommand(self, program, platform,
+    def _composeRunCommand(self, env_vars, program, platform,
                            test, inputs, outputs):
-        cmd = [program,
+        cmd = [env_vars, program,
                "--json", platform.getOutputDir() + "report.json",
                "--input", ' ' .join(inputs),
                "--output", ' '.join(outputs)]


### PR DESCRIPTION
Summary:
Some of the devices we run with require playing with the
LD_LIBRARY_PATH to run correctly. Modify harness.py so that it can accept that
option.

Differential Revision: D15109127

