### PR TITLE
add back codes for downloading from http source

### DIFF
--- a/benchmarking/download_benchmarks/download_benchmarks.py
+++ b/benchmarking/download_benchmarks/download_benchmarks.py
@@ -73,16 +73,15 @@ class DownloadBenchmarks(object):
 
     def downloadFile(self, location, md5):
         if location.startswith("http"):
-            if location[0:2] != "//":
-                dirs = location.split(":/")
-                replace_pattern = {
-                        ' ': '-',
-                        '\\': '-',
-                        ':': '/',
-                }
-                path = self.root_model_dir + '/' +\
-                       getFilename(location, replace_pattern=replace_pattern)
-        elif location[0:2] != "//":
+            dirs = location.split(":/")
+            replace_pattern = {
+                    ' ': '-',
+                    '\\': '-',
+                    ':': '/',
+            }
+            path = self.root_model_dir + '/' +\
+                    getFilename(location, replace_pattern=replace_pattern)
+        elif not location.startswith("//"):
             return
         else:
             dirs = location[2:].split("/")

--- a/benchmarking/download_benchmarks/download_benchmarks.py
+++ b/benchmarking/download_benchmarks/download_benchmarks.py
@@ -72,7 +72,17 @@ class DownloadBenchmarks(object):
                 self._downloadTestFiles(test["postprocess"]["files"])
 
     def downloadFile(self, location, md5):
-        if location[0:2] != "//":
+        if location.startswith("http"):
+            if location[0:2] != "//":
+                dirs = location.split(":/")
+                replace_pattern = {
+                        ' ': '-',
+                        '\\': '-',
+                        ':': '/',
+                }
+                path = self.root_model_dir + '/' +\
+                       getFilename(location, replace_pattern=replace_pattern)
+        elif location[0:2] != "//":
             return
         else:
             dirs = location[2:].split("/")


### PR DESCRIPTION
Summary: with Django's file storage logic, the client side would build a binary and upload it to the Django server, with the file path identified with an http address. The lab side would then download the file from the path. Thus, these lines are necessary for the lab site to properly download the file from the server.

Test plan: tested with the end-to-end workflow for starting the lab and triggering the remote benchmark run.