### PR TITLE
Resolve a missing parameter in docker example

### DIFF
--- a/specifications/docker/docker_pytorch.sh
+++ b/specifications/docker/docker_pytorch.sh
@@ -49,6 +49,7 @@ echo "
   \"--remote_repository\": \"origin\",
   \"--repo\": \"git\",
   \"--repo_dir\": \"${REPO_DIR}\",
+  \"--root_model_dir\": \"${CONFIG_DIR}/root_model_dir\",
   \"--screen_reporter\": null
 }
 " > ${CONFIG_DIR}/config.txt

--- a/specifications/docker/docker_tflite.sh
+++ b/specifications/docker/docker_tflite.sh
@@ -51,6 +51,7 @@ echo "
   \"--remote_repository\": \"origin\",
   \"--repo\": \"git\",
   \"--repo_dir\": \"${REPO_DIR}\",
+  \"--root_model_dir\": \"${CONFIG_DIR}/root_model_dir\",
   \"--screen_reporter\": null
 }
 " > ${CONFIG_DIR}/config.txt


### PR DESCRIPTION
Resolve a missing parameter (`--root_model_dir`) in tflite docker example.

Solve #284