### PR TITLE
fix load hash_platform_mapping

### DIFF
--- a/benchmarking/platforms/platform_base.py
+++ b/benchmarking/platforms/platform_base.py
@@ -42,7 +42,7 @@ class PlatformBase(object):
         else:
             # otherwise read from internal
             try:
-                from specifications.hash_platform_mapping import hash_platform_mapping
+                from aibench.specifications.hash_platform_mapping import hash_platform_mapping
                 self.hash_platform_mapping = hash_platform_mapping
             except BaseException:
                 pass


### PR DESCRIPTION
Summary: The `base_module` has been changed in D14605802, and I forgot to change the import path here so it will not load `hash_platform_mapping`.

Differential Revision: D15292907

