### PR TITLE
fix remote run random failures

### DIFF
--- a/benchmarking/remote/screen_reporter.py
+++ b/benchmarking/remote/screen_reporter.py
@@ -70,7 +70,7 @@ class ScreenReporter(object):
         output = self.xdb.getBenchmarks(str(s["id"]))
         for r in output:
             if s["status"] == "DONE":
-                res = json.loads(r["result"])
+                res = json.loads(r["result"]) if r["result"] else []
                 benchmarks = json.loads(r["benchmarks"])
                 metric = benchmarks["benchmark"]["content"]["tests"][0]["metric"]
                 for identifier in res:


### PR DESCRIPTION
Summary:
In some rare cases, output might be like P64510428 such that 'result': None,

In these cases, we will get some failures like
{F158632919}

Differential Revision: D15332963

