### PR TITLE
add info when skip uploading

### DIFF
--- a/benchmarking/remote/file_handler.py
+++ b/benchmarking/remote/file_handler.py
@@ -66,6 +66,7 @@ class FileHandler(object):
             path = os.path.dirname(os.path.realpath(basefilename)) + "/" + filename
 
         if not os.path.isfile(path):
+            getLogger().info("Skip uploading {}".format(filename))
             return filename, md5
 
         upload_path, cached_md5 = self._getCachedFile(path)


### PR DESCRIPTION
Summary:
As Peizhao Zhang suggested, I am adding some info here to notify that files were not gonna to upload.

Background: if the absolute path of the user specified file cannot be found, PEP does not give any information like file cannot be found.

Differential Revision: D15336327

