### PR TITLE
fix moving files when md5 is null

### DIFF
--- a/benchmarking/benchmarks/benchmarks.py
+++ b/benchmarking/benchmarks/benchmarks.py
@@ -182,6 +182,8 @@ class BenchmarkCollector(object):
     def _updateOneFile(self, field, model_dir, filename):
         cached_filename = \
             self._getDestFilename(field, model_dir)
+        if "md5" in field and field["md5"] is None and "HOSTDIR" not in field["location"]:
+            return self._copyFile(field, cached_filename, filename)
         if "md5" in field and field["md5"] is not None and\
                 (not os.path.isfile(cached_filename) or
                  self._calculateMD5(cached_filename) != field["md5"]):

--- a/benchmarking/run_lab.py
+++ b/benchmarking/run_lab.py
@@ -155,9 +155,10 @@ class runAsync(object):
         try:
             app = BenchmarkDriver(raw_args=raw_args)
             status = app.run()
-        except Exception:
+        except Exception as e:
             msg = " ".join(raw_args)
             getLogger().error(msg)
+            getLogger().error(e)
 
         output = log_capture_string.getvalue()
         log_capture_string.close()


### PR DESCRIPTION
Summary:
This diff will fix what has been described here https://fb.workplace.com/groups/1690415234371429/permalink/2212522388827375/.

When user provided file locations with `everstore` and `"md5": null`, PEP will return `update_json=False`. This means PEP will go ahead to look for files under `.aibench/hg/model_cache/caffe2/` (in this case `.aibench/hg/model_cache/caffe2/default_conflated`). Whatever files saved under `.aibench/hg/model_cache/caffe2/default_conflated` will be used to run the model.

The fix would be adding a new scenario to handle such case such that it will always move files over to overwrite the files under `model_cache`.

Differential Revision: D15681118

