### PR TITLE
skip extra when uploading files

### DIFF
--- a/benchmarking/run_remote.py
+++ b/benchmarking/run_remote.py
@@ -382,6 +382,8 @@ class RunRemote(object):
             assert ref_path is not None, "repo is not yet \
                 supported for {}".format(location)
             for side in self.info:
+                if side == "extra":
+                    continue
                 value = self.info[side]
                 commit_hash = "master"
                 if "commit" in value:


### PR DESCRIPTION
Summary: When there is `extra` in `info`, we want to skip it for uploading files.

Differential Revision: D15931464

