### PR TITLE
reduce number of jobs submitted from contbuild

### DIFF
--- a/benchmarking/repo_driver.py
+++ b/benchmarking/repo_driver.py
@@ -324,7 +324,7 @@ class RepoDriver(object):
             datetime.datetime.now().strftime("%Y_%m_%d_%H_%M"))
         self.executables_builder.start()
         self._runBenchmarkSuites()
-        sys.exit(getRunStatus())
+        return getRunStatus()
 
     def _runBenchmarkSuites(self):
         # initially sleep 10 seconds in case no need to build the binary


### PR DESCRIPTION
Summary:
There were too many jobs submitted to PEP after D16002892.

Instead I created one empty TEST_JSON and asked it run locally on sandcastle, and removed two remote runs for test.

Differential Revision: D16032628

