### PR TITLE
use tabulate to print devices

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -45,7 +45,7 @@ sudo apt-get update
 # confirm python version
 python --version
 
-pip install six requests
+pip install six requests tabulate
 
 case ${FRAMEWORK} in
   PYTORCH)

--- a/benchmarking/run_remote.py
+++ b/benchmarking/run_remote.py
@@ -22,6 +22,7 @@ import pkg_resources
 from random import randint
 import re
 import shutil
+from tabulate import tabulate
 import tempfile
 import threading
 import subprocess
@@ -437,11 +438,22 @@ class RunRemote(object):
 
     def _listDevices(self):
         devices = self.db.listDevices(self.args.job_queue)
+        headers = ["Device", "Status", "Abbrs", "Claimer"]
+        rows = []
         for device in devices:
             abbrs = self.devices.getAbbrs(device["device"])
-            print(device["status"] + "\t" +
-                  device["device"] +
-                  (" (" + ",".join(abbrs) + ")" if abbrs else ""))
+            abbrs = ",".join(abbrs) if abbrs else ""
+            if self.args.job_queue in ["android", "ios"]:
+                claimer = device["hash"]
+            else:
+                claimer = device["claimer"]
+            row = [device["device"], device["status"], abbrs, claimer]
+            rows.append(row)
+        rows.sort()
+        print()
+        print(tabulate(rows, headers=headers, tablefmt='orgtbl'))
+        print()
+        return rows
 
     def _checkDevices(self, specified_devices):
         devices = set()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
-setuptools>=39.0.1
-six>=1.11.0
-requests>=2.21.0
-numpy>=1.13.3
-Monsoon>=0.1.88
 Django>=2.2.1
+Monsoon>=0.1.88
 matplotlib>=3.0.3
 mock>=3.0.3
+numpy>=1.13.3
 onnx>=1.5.0
+requests>=2.21.0
+setuptools>=39.0.1
+six>=1.11.0
+tabulate>=0.8.3


### PR DESCRIPTION
Summary: We added device's hash/claimer_id when `--remote --list_devices`, also change the table format by using tabulate.

Differential Revision: D16039708

