### PR TITLE
insert claimer only when not None

### DIFF
--- a/benchmarking/bridge/db.py
+++ b/benchmarking/bridge/db.py
@@ -42,8 +42,9 @@ class DBDriver(object):
             'devices': devices,
             'benchmarks': json_data,
             'user': user,
-            'claimer': claimer,
         }
+        if claimer:
+            params['claimer'] = claimer
         self._requestData(params)
 
     def claimBenchmarks(self, server_id, devices):


### PR DESCRIPTION
Summary: I thought Python `requests` will insert `claimer=NULL` when it is `None`, but it inserts ``.

Reviewed By: mingzhe09088

Differential Revision: D16059520

