### PR TITLE
allow legacy codes

### DIFF
--- a/benchmarking/frameworks/framework_base.py
+++ b/benchmarking/frameworks/framework_base.py
@@ -174,12 +174,15 @@ class FrameworkBase(object):
             # Fix the number of threads
             if not platform_args.get("env", False):
                 platform_args["env"] = {}
-            platform_args["env"]["MKL_NUM_THREADS"] = test.get("num_threads", 1)
-            platform_args["env"]["OMP_NUM_THREADS"] = test.get("num_threads", 1)
+            num_threads = test.get("num_threads", 1)
+            if num_threads > 0:
+                platform_args["env"]["MKL_NUM_THREADS"] = num_threads
+                platform_args["env"]["OMP_NUM_THREADS"] = num_threads
             # Fix the specfic cpu core to run the program
             cpu_core = test.get("cpu-list", 4)
-            test["commands"][-1] = " ".join(["taskset", "--cpu-list", str(cpu_core),
-                test["commands"][-1]])
+            if isinstance(test["commands"], list):
+                test["commands"][-1] = " ".join([
+                    "taskset", "--cpu-list", str(cpu_core), test["commands"][-1]])
 
         self._runCommands(output, test["commands"], platform, programs, model,
                           test, tgt_model_files, tgt_input_files,


### PR DESCRIPTION
Summary: After D16676619, we found there are some FAILED and USER_ERROR from the run, either due to the legacy way of writing json or the json is actually testing multi-thread.

Differential Revision: D16723763

