### PR TITLE
Inject default iter parameter into tests

### DIFF
--- a/benchmarking/frameworks/framework_base.py
+++ b/benchmarking/frameworks/framework_base.py
@@ -87,6 +87,11 @@ class FrameworkBase(object):
             converter = None
 
         output = {}
+
+        # inject default parameters into test
+        if "iter" not in test:
+            test["iter"] = -1
+
         # overall preprocess
         if "preprocess" in model and first_iteration:
             commands = model["preprocess"]["commands"]


### PR DESCRIPTION
Summary: Inject the default iter parameter into tests if not configured in the benchmark definition. The no longer required parameters have now been removed from config files.

Differential Revision: D16941475

