### PR TITLE
Adding logic for enabling profiling on platforms

### DIFF
--- a/benchmarking/driver/benchmark_driver.py
+++ b/benchmarking/driver/benchmark_driver.py
@@ -133,7 +133,16 @@ def _processDelayData(input_data):
 
 def _mergeDelayData(treatment_data, control_data, bname):
     data = copy.deepcopy(treatment_data)
+    # meta is not a metric, so handle is seperatly
+    data["meta"] = _mergeDelayMeta(
+        treatment_data["meta"],
+        control_data["meta"],
+        bname
+    )
     for k in treatment_data:
+        # meta was already merged, so don't try to merge it again
+        if k == "meta":
+            continue
         if k not in control_data:
             getLogger().error(
                 "Value {} existed in treatment but not ".format(k) +
@@ -184,6 +193,18 @@ def _mergeDelayData(treatment_data, control_data, bname):
                 diff_summary["mean"] = tsummary["mean"] - csummary["mean"]
             data[k]['diff_summary'] = diff_summary
     return data
+
+
+def _mergeDelayMeta(treatment_meta, control_meta, bname):
+    meta = copy.deepcopy(treatment_meta)
+    for k in treatment_meta:
+        if k not in control_meta:
+            getLogger().error(
+                "Value {} existed in treatment but not ".format(k)
+                + "control for benchmark {}".format(bname))
+            continue
+        meta["control_{}".format(k)] = control_meta[k]
+    return meta
 
 
 def _processErrorData(treatment_files, golden_files):

--- a/benchmarking/frameworks/caffe2/caffe2.py
+++ b/benchmarking/frameworks/caffe2/caffe2.py
@@ -255,7 +255,8 @@ class Caffe2Framework(FrameworkBase):
         num = 0
         # emulate do...while... loop
         while True:
-            output = platform.runBenchmark(cmd, platform_args=platform_args)
+            output, meta = platform.runBenchmark(cmd,
+                                                 platform_args=platform_args)
             one_result, valid_run_idxs = \
                 converter_obj.collect(output, args)
             valid_run_idxs = [num + idx for idx in valid_run_idxs]
@@ -285,4 +286,5 @@ class Caffe2Framework(FrameworkBase):
                 results = results[valid_run_idxs[num - total_num]:]
             break
         metric = converter_obj.convert(results)
+        metric["meta"] = meta
         return metric

--- a/benchmarking/frameworks/framework_base.py
+++ b/benchmarking/frameworks/framework_base.py
@@ -386,7 +386,14 @@ class FrameworkBase(object):
                                       model_files,
                                       input_files, output_files,
                                       shared_libs, test_files, main_command)
-        for cmd in cmds:
+        profiling_enabled = False
+        if "profiler" in test:
+            profiling_enabled = test["profiler"].get("enabled", False)
+        for idx, cmd in enumerate(cmds):
+            # note that we only enable profiling for the last command
+            # of the main commands.
+            platform_args["enable_profiling"] = profiling_enabled and \
+                main_command and idx == len(cmds) - 1
             one_output = self.runOnPlatform(total_num, cmd, platform,
                                             platform_args,
                                             converter)

--- a/benchmarking/frameworks/generic/generic.py
+++ b/benchmarking/frameworks/generic/generic.py
@@ -54,7 +54,7 @@ class GenericFramework(FrameworkBase):
                 entry["location"], target))
 
         # run benchmark
-        output = platform.runBenchmark(commands, log_to_screen_only=True)
+        output, meta = platform.runBenchmark(commands, log_to_screen_only=True)
 
         # todo: output files
         output_files = None

--- a/benchmarking/frameworks/pytorch/pytorch.py
+++ b/benchmarking/frameworks/pytorch/pytorch.py
@@ -42,7 +42,8 @@ class PytorchFramework(Caffe2Framework):
         platform_args["ignore_status"] = True
         # emulate do...while... loop
         while True:
-            output = platform.runBenchmark(cmd, platform_args=platform_args)
+            output, meta = platform.runBenchmark(cmd,
+                                                 platform_args=platform_args)
             one_result, valid_run_idxs = \
                 converter_obj.collect(output, args)
             valid_run_idxs = [num + idx for idx in valid_run_idxs]
@@ -69,4 +70,5 @@ class PytorchFramework(Caffe2Framework):
                 results = results[valid_run_idxs[num - total_num]:]
             break
         metric = converter_obj.convert(results)
+        metric["meta"] = meta
         return metric

--- a/benchmarking/frameworks/tflite/tflite.py
+++ b/benchmarking/frameworks/tflite/tflite.py
@@ -85,9 +85,10 @@ class TFLiteFramework(FrameworkBase):
 
     def runOnPlatform(self, total_num, cmd, platform, platform_args,
                       converter_class):
-        output = platform.runBenchmark(cmd, platform_args=platform_args,
-                                       log_to_screen_only=True)
+        output, meta = platform.runBenchmark(cmd, platform_args=platform_args,
+                                             log_to_screen_only=True)
         result = self._collectData(output)
+        result["meta"] = meta
         return result
 
     def _collectData(self, output):

--- a/benchmarking/platforms/android/android_platform.py
+++ b/benchmarking/platforms/android/android_platform.py
@@ -109,6 +109,16 @@ class AndroidPlatform(PlatformBase):
     def runBenchmark(self, cmd, *args, **kwargs):
         if not isinstance(cmd, list):
             cmd = shlex.split(cmd)
+
+        # profiling is not supported on android
+        if "platform_args" in kwargs and \
+           "enable_profiling" in kwargs["platform_args"]:
+            del kwargs["platform_args"]["enable_profiling"]
+
+        # meta is used to store any data about the benchmark run
+        # that is not the output of the command
+        meta = {}
+
         # We know this command may fail. Avoid propogating this
         # failure to the upstream
         success = getRunStatus()
@@ -118,7 +128,7 @@ class AndroidPlatform(PlatformBase):
             log = self.runAppBenchmark(cmd, *args, **kwargs)
         else:
             log = self.runBinaryBenchmark(cmd, *args, **kwargs)
-        return log
+        return log, meta
 
     def runAppBenchmark(self, cmd, *args, **kwargs):
         arguments = self.getPairedArguments(cmd)

--- a/benchmarking/platforms/ios/ios_platform.py
+++ b/benchmarking/platforms/ios/ios_platform.py
@@ -89,6 +89,13 @@ class IOSPlatform(PlatformBase):
             if "power" in platform_args and platform_args["power"]:
                 platform_args["non_blocking"] = True
                 run_cmd += ["--justlaunch"]
+        # profiling is not supported on ios
+        if "enable_profiling" in platform_args:
+            del platform_args["enable_profiling"]
+
+        # meta is used to store any data about the benchmark run
+        # that is not the output of the command
+        meta = {}
 
         if arguments:
             run_cmd += ["--args",
@@ -96,7 +103,7 @@ class IOSPlatform(PlatformBase):
                                   for x in arguments])]
         # the command may fail, but the err_output is what we need
         log_screen = self.util.run(run_cmd, **platform_args)
-        return log_screen
+        return log_screen, meta
 
     def rebootDevice(self):
         success = self.util.reboot()

--- a/benchmarking/platforms/platform_base.py
+++ b/benchmarking/platforms/platform_base.py
@@ -76,7 +76,7 @@ class PlatformBase(object):
 
     @abc.abstractmethod
     def runBenchmark(self, cmd, *args, **kwargs):
-        return None
+        return None, None
 
     @abc.abstractmethod
     def preprocess(self, *args, **kwargs):

--- a/benchmarking/profilers/profilers.py
+++ b/benchmarking/profilers/profilers.py
@@ -15,11 +15,15 @@ from __future__ import unicode_literals
 
 
 profilers = {}
+profilersByUsage = {}
 
 
-def registerProfiler(name, profiler):
+def registerProfiler(name, profiler, usage=None):
     global profilers
+    global profilersByUsage
     profilers[name] = profiler
+    if usage:
+        profilersByUsage[usage] = profiler
 
 
 def getProfiler(name, id=None):
@@ -27,3 +31,10 @@ def getProfiler(name, id=None):
     if name not in profilers:
         return None
     return profilers[name](id)
+
+
+def getProfilerByUsage(usage, id=None):
+    global profilersByUsage
+    if usage not in profilersByUsage:
+        return None
+    return profilersByUsage[usage](id)


### PR DESCRIPTION
Summary: This diff adds the logic to enable profiling on specific commands. It also adds the handling of setting enable_profiling on unsupported platforms so that all runs will continue to operate as normal.

Differential Revision: D17075457

