### PR TITLE
Add support for customizing arguements to profilers

### DIFF
--- a/benchmarking/frameworks/framework_base.py
+++ b/benchmarking/frameworks/framework_base.py
@@ -389,6 +389,8 @@ class FrameworkBase(object):
         profiling_enabled = False
         if "profiler" in test:
             profiling_enabled = test["profiler"].get("enabled", False)
+        if profiling_enabled:
+            platform_args["profiler_args"] = test["profiler"]
         for idx, cmd in enumerate(cmds):
             # note that we only enable profiling for the last command
             # of the main commands.

--- a/benchmarking/platforms/android/android_platform.py
+++ b/benchmarking/platforms/android/android_platform.py
@@ -114,6 +114,9 @@ class AndroidPlatform(PlatformBase):
         if "platform_args" in kwargs and \
            "enable_profiling" in kwargs["platform_args"]:
             del kwargs["platform_args"]["enable_profiling"]
+        if "platform_args" in kwargs and \
+           "profiler_args" in kwargs["platform_args"]:
+            del kwargs["platform_args"]["profiler_args"]
 
         # meta is used to store any data about the benchmark run
         # that is not the output of the command

--- a/benchmarking/platforms/host/host_platform.py
+++ b/benchmarking/platforms/host/host_platform.py
@@ -64,6 +64,10 @@ class HostPlatform(PlatformBase):
             runAsync = platform_args["enable_profiling"]
             del platform_args["enable_profiling"]
         platform_args["async"] = runAsync
+        profiler_args = {}
+        if "profiler_args" in platform_args:
+            profiler_args = platform_args["profiler_args"]
+            del platform_args["profiler_args"]
 
         # meta is used to store any data about the benchmark run
         # that is not the output of the command
@@ -82,7 +86,7 @@ class HostPlatform(PlatformBase):
         profiler = getProfilerByUsage("server")
 
         if profiler:
-            profilerFuture = profiler.start()
+            profilerFuture = profiler.start(**profiler_args)
 
         output, _ = processWait(procAndTimeout, **platform_args)
 

--- a/benchmarking/platforms/ios/ios_platform.py
+++ b/benchmarking/platforms/ios/ios_platform.py
@@ -92,6 +92,8 @@ class IOSPlatform(PlatformBase):
         # profiling is not supported on ios
         if "enable_profiling" in platform_args:
             del platform_args["enable_profiling"]
+        if "profiler_args" in platform_args:
+            del platform_args["profiler_args"]
 
         # meta is used to store any data about the benchmark run
         # that is not the output of the command

--- a/benchmarking/profilers/profiler_base.py
+++ b/benchmarking/profilers/profiler_base.py
@@ -22,13 +22,13 @@ class ProfilerBase(object):
     def __init__(self, id=None):
         self.id = id
 
-    def start(self):
+    def start(self, **kwargs):
         f = Future(self._start)
-        f.start(self.id)
+        f.start(self.id, **kwargs)
         return f
 
     @abc.abstractmethod
-    def _start(self, id):
+    def _start(self, id, **kwargs):
         return None
 
     def getId(self, f):

--- a/benchmarking/utils/future.py
+++ b/benchmarking/utils/future.py
@@ -30,8 +30,12 @@ class Future(object):
         self.finished = False
         self.joined = False
 
-    def start(self, *args):
-        self.thread = threading.Thread(target=self._runAndCapture, args=args)
+    def start(self, *args, **kwargs):
+        self.thread = threading.Thread(
+            target=self._runAndCapture,
+            args=args,
+            kwargs=kwargs
+        )
         self.thread.start()
 
     def result(self):
@@ -44,6 +48,6 @@ class Future(object):
     def isFinished(self):
         return self.finished
 
-    def _runAndCapture(self, *args):
-        self.retval = self.func(*args)
+    def _runAndCapture(self, *args, **kwargs):
+        self.retval = self.func(*args, **kwargs)
         self.finished = True


### PR DESCRIPTION
Summary:
Users can now specify arguments to the profiler in the profiler section of
their test json specification.

Differential Revision: D17176926

