### PR TITLE
Allow config overrides to be read in from config_overrides.txt

### DIFF
--- a/benchmarking/run_bench.py
+++ b/benchmarking/run_bench.py
@@ -180,8 +180,13 @@ class RunBench(object):
                 not os.path.isfile(os.path.join(self.root_dir, "config.txt")):
             args = self._saveDefaultArgs(new_args)
         else:
-            with open(os.path.join(self.root_dir, "config.txt"), "r") as f:
-                args = json.load(f)
+            args = {}
+            tiered_configs = ["config.txt", "config_overrides.txt"]
+            for config in tiered_configs:
+                config_file = os.path.join(self.root_dir, config)
+                if os.path.isfile(config_file):
+                    with open(config_file, "r") as f:
+                        args.update(json.load(f))
         for v in new_args:
             if v in args:
                 del args[v]

--- a/benchmarking/run_lab.py
+++ b/benchmarking/run_lab.py
@@ -37,7 +37,7 @@ from platforms.android.adb import ADB
 from reboot_device import reboot as reboot_device
 from utils.check_argparse import claimer_id_type
 from utils.custom_logger import getLogger, setLoggerLevel
-from utils.utilities import getFilename
+from utils.utilities import getFilename, getMachineId
 
 
 parser = argparse.ArgumentParser(description="Run the benchmark remotely")
@@ -47,9 +47,9 @@ parser.add_argument("--android_dir", default="/data/local/tmp/",
 parser.add_argument("--app_id",
     help="The app id you use to upload/download your file for everstore "
     "and access the job queue")
-parser.add_argument("--claimer_id", required=True, type=claimer_id_type,
-    help="A unique claimer id to represent itself. Must talk to Caffe2 team "
-    "to set it up.")
+parser.add_argument("--claimer_id", default=getMachineId(),
+    type=claimer_id_type, help="A unique claimer id to represent itself. "
+    "Must talk to Caffe2 team to set it up.")
 parser.add_argument("--cooldown", default=0, type=float,
     help="Specify the time interval between two test runs.")
 parser.add_argument("-d", "--devices",

--- a/benchmarking/utils/utilities.py
+++ b/benchmarking/utils/utilities.py
@@ -20,6 +20,8 @@ import requests
 from six import string_types
 import sys
 from time import sleep
+import socket
+import uuid
 
 from .custom_logger import getLogger
 
@@ -260,3 +262,10 @@ def getMeta(args, platform):
         with open(meta_file, "r") as f:
             meta = json.load(f)
     return meta
+
+
+def getMachineId():
+    ident = socket.getfqdn()
+    if len(ident) == 0 or ident == 'localhost':
+        ident = uuid.uuid1().hex
+    return ident


### PR DESCRIPTION
Summary:
Currently we have a different set of cli args for every machine. Since we want
to start aibench using a chef config we need the command for starting aibench
to be the same for all machines. In order to do that we are allowing machine
specific configs to be read from config_overrides.txt instead of from cli
flags.

Differential Revision: D17216679

