### PR TITLE
Bump timeout for test portion of circleci jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ linux_default: &linux_default
         docker exec -e CIRCLE_JOB=${CIRCLE_JOB} -e SCCACHE_BUCKET=${SCCACHE_BUCKET} -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_FOR_SCCACHE_S3_BUCKET} -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY_FOR_SCCACHE_S3_BUCKET} -u jenkins $(cat .docker_pid) .circleci/build.sh
   - run:
       name: Test
-      no_output_timeout: "1h"
+      no_output_timeout: "3h"
       command: |
         docker exec -e CIRCLE_JOB=${CIRCLE_JOB} -u jenkins $(cat .docker_pid) .circleci/test.sh
 


### PR DESCRIPTION
Summary:
Executing build.sh for the squeezenet model frequently takes over an hour.
During this process no output is generated, causing circleci to kill the job.
By bumping the timeout to 3hrs, we can prevent this issue.

Differential Revision: D17277844

