### PR TITLE
use string/TEXT for string_map from continuous runs

### DIFF
--- a/benchmarking/frameworks/framework_base.py
+++ b/benchmarking/frameworks/framework_base.py
@@ -13,17 +13,17 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 import abc
+import ast
 import json
 import os
 import re
-import signal
 import shutil
 from six import string_types
 
 from data_converters.data_converters import getConverters
 from platforms.platforms import getHostPlatform
-from utils.subprocess_with_logger import processRun
-from utils.utilities import deepMerge, deepReplace, getFAIPEPROOT, getString
+from utils.utilities import deepMerge, deepReplace, \
+    getFAIPEPROOT, getString
 
 
 class FrameworkBase(object):
@@ -431,11 +431,17 @@ class FrameworkBase(object):
         return hostdir
 
     def _replaceStringMap(self, root, platform, program_path, stringmap_from_info):
-        string_map = json.loads(self.args.string_map) \
-            if self.args.string_map else {}
+        try:
+            # backward compatible
+            string_map = json.loads(self.args.string_map) \
+                if self.args.string_map else {}
 
-        info_string_map = json.loads(stringmap_from_info) \
-            if stringmap_from_info else {}
+            info_string_map = json.loads(stringmap_from_info) \
+                if stringmap_from_info else {}
+        except BaseException:
+            string_map = ast.literal_eval(self.args.string_map) \
+                if self.args.string_map else {}
+            info_string_map = stringmap_from_info if stringmap_from_info else {}
 
         deepMerge(string_map, info_string_map)
 


### PR DESCRIPTION
Summary:
Mobilelab released their new `lab-cli` tool (https://fb.workplace.com/groups/128227381151462/permalink/380814102559454/). However, the new tool seems does not work with ai_bench tests.

After talking with Peter Strand, we think the problem is due to `string_map` in ai_bench tests.

This diff is changing `string_map` to pure string from config repo, and not just `json.dumps`. In fbcode, we use `ast` to decode `dict` instead of `json.dumps` and `AB_STRUCT`.

Reviewed By: BIT-silence

Differential Revision: D16735113

