### PR TITLE
Provide pid to profiler for gpu tracing

### DIFF
--- a/benchmarking/platforms/host/host_platform.py
+++ b/benchmarking/platforms/host/host_platform.py
@@ -83,7 +83,7 @@ class HostPlatform(PlatformBase):
 
         ps, _ = procAndTimeout
 
-        profiler = getProfilerByUsage("server")
+        profiler = getProfilerByUsage("server", os.getpid())
 
         if profiler:
             profilerFuture = profiler.start(**profiler_args)


### PR DESCRIPTION
Summary:
The proc_name option is required by perf_doctor for tracing. It will be ignored for
non tracing deep_runlist options. This option does recurse into child
processes, which is why we pass in the pid of AIBench.

Reviewed By: hl475

Differential Revision: D17375589

