### PR TITLE
correct PyTorchObserver in observer

### DIFF
--- a/benchmarking/utils/observer.py
+++ b/benchmarking/utils/observer.py
@@ -15,7 +15,7 @@ import json
 
 # converts the passed in fields into one of the formats expected by the data converter
 # and prepends the identifer to the json string
-def emitMetric(identifier="PytorchObserver", **kwargs):
+def emitMetric(identifier="PyTorchObserver", **kwargs):
     data = {}
     # check basic fields in all formats are present
     if "type" not in kwargs or "metric" not in kwargs or "unit" not in kwargs:


### PR DESCRIPTION
Summary: We have https://fburl.com/diffusion/dtzwi1xr with `IDENTIFIER = 'PyTorchObserver '`. However, our observer has `PytorchObserver`.

Reviewed By: ASankaran

Differential Revision: D17439107

