### PR TITLE
Fix error with overriding benchmark default args via cli flags

### DIFF
--- a/benchmarking/run_bench.py
+++ b/benchmarking/run_bench.py
@@ -227,8 +227,8 @@ class RunBench(object):
             return
 
         # Remove args which are further overidden via cli flags
-        for arg in defaults:
-            if arg in unknowns:
+        for arg in unknowns:
+            if arg in defaults:
                 del defaults[arg]
 
         # Override args with default_overrides


### PR DESCRIPTION
Summary:
Overriding args via the cli was breaking because the original code was
attempting to modify the dictionary it was iterating over. This diff resolves
that issue by instead iterating over the list of unknowns.

Differential Revision: D17587206

