### PR TITLE
Add stubs for simple remote runs

### DIFF
--- a/benchmarking/frameworks/generic/generic.py
+++ b/benchmarking/frameworks/generic/generic.py
@@ -18,53 +18,16 @@ from frameworks.framework_base import FrameworkBase
 
 class GenericFramework(FrameworkBase):
     def __init__(self, tempdir, args):
+        super(GenericFramework, self).__init__(args)
         self.tempdir = os.path.join(tempdir, self.getName())
         os.makedirs(self.tempdir, 0o777)
 
     def getName(self):
         return "generic"
 
-    def runBenchmark(self, info, benchmark, platform):
-        tests = benchmark["tests"]
-        assert len(tests) == 1, "At this point, only one test should " + \
-            "exist in one benchmark. However, benchmark " + \
-            "{} doesn't.".format(benchmark["name"])
-        test = tests[0]
-
-        model = None
-        if "model" in benchmark:
-            model = benchmark["model"]
-
-        program = platform.copyFilesToPlatform(info["programs"]["program"]["location"])
-
-        commands = test["commands"]
-        model_files = None
-        if model is not None and "files" in model:
-            model_files = {name: model["files"][name]["location"]
-                           for name in model["files"]}
-            model_files = \
-                platform.copyFilesToPlatform(model_files)
-
-        libraries = []
-        if "libraries" in model:
-            for entry in model["libraries"]:
-                target = entry["target"] \
-                    if "target" in entry else platform.adb.dir
-            libraries.append(platform.copyFilesToPlatform(
-                entry["location"], target))
-
-        # run benchmark
-        output, meta = platform.runBenchmark(commands, log_to_screen_only=True)
-
-        # todo: output files
-        output_files = None
-
-        # cleanup
-        if model_files:
-            platform.delFilesFromPlatform(model_files)
-        platform.delFilesFromPlatform(program)
-
-        return output, output_files
-
-    def verifyBenchmarkFile(self, benchmark, filename, is_post):
-        pass
+    def runOnPlatform(self, total_num, cmd, platform, platform_args,
+                      converter):
+        _, meta = platform.runBenchmark(cmd, platform_args=platform_args)
+        results = {}
+        results["meta"] = meta
+        return results

--- a/benchmarking/lab_driver.py
+++ b/benchmarking/lab_driver.py
@@ -52,7 +52,8 @@ class LabDriver(object):
         setLoggerLevel(self.args.logger_level)
 
     def run(self):
-        if not self.args.lab and not self.args.remote:
+        if not self.args.lab and not self.args.remote and \
+                not "--adhoc" not in self.args:
             assert self.args.benchmark_file, \
                 "--benchmark_file (-b) must be specified"
 

--- a/benchmarking/run_bench.py
+++ b/benchmarking/run_bench.py
@@ -16,8 +16,10 @@ import argparse
 import copy
 import json
 import os
+import pkg_resources
 import six
 import sys
+import tempfile
 
 from lab_driver import LabDriver
 from utils.custom_logger import getLogger, setLoggerLevel
@@ -211,6 +213,16 @@ class RunBench(object):
             benchmark_file = unknowns["--benchmark_file"]
         if not benchmark_file and "-b" in unknowns:
             benchmark_file = unknowns["-b"]
+        # Remove later when adhoc is moved to seperated infrastructure
+        if "--adhoc" in unknowns:
+            fd, path = tempfile.mkstemp()
+            with pkg_resources.resource_stream(
+                "aibench",
+                "specifications/models/generic/adhoc.json"
+            ) as stream:
+                with os.fdopen(fd, 'wb') as f:
+                    f.write(stream.read())
+            benchmark_file = path
         if not benchmark_file:
             return
 

--- a/benchmarking/run_remote.py
+++ b/benchmarking/run_remote.py
@@ -130,6 +130,8 @@ parser.add_argument("--user_identifier",
     help="The identifier user pass in to differentiate different benchmark runs.")
 parser.add_argument("--user_string",
     help="The user_string pass in to differentiate different regression benchmark runs.")
+parser.add_argument("--adhoc", action="store_true",
+    help="Use the adhoc template file")
 
 
 class BuildProgram(threading.Thread):
@@ -184,6 +186,7 @@ class BuildProgram(threading.Thread):
 class RunRemote(object):
     def __init__(self, raw_args=None):
         self.args, self.unknowns = parser.parse_known_args(raw_args)
+        self._updateArgs(self.args)
         setLoggerLevel(self.args.logger_level)
         if not self.args.benchmark_db_entry:
             assert self.args.server_addr is not None, \
@@ -612,6 +615,18 @@ class RunRemote(object):
             "type": type,
             "unit": unit,
         }
+
+    def _updateArgs(self, args):
+        # Remove later when adhoc is moved to seperated infrastructure
+        if args.adhoc:
+            fd, path = tempfile.mkstemp()
+            with pkg_resources.resource_stream(
+                "aibench",
+                "specifications/models/generic/adhoc.json"
+            ) as stream:
+                with os.fdopen(fd, 'wb') as f:
+                    f.write(stream.read())
+            args.benchmark_file = path
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
We want to allow users to perform simple adhoc runs without needing a lot of
configuration. With this diffs users will be able to just modify the build.sh
file for platform host/adhoc in their local repo and then start an adhoc
benchmark with the adhoc json template. Users can also further modify the json
specification for more customizability.

Differential Revision: D17639337

