### PR TITLE
Set default values for result for failed runs

### DIFF
--- a/benchmarking/driver/benchmark_driver.py
+++ b/benchmarking/driver/benchmark_driver.py
@@ -70,6 +70,13 @@ def runOneBenchmark(info, benchmark, framework, platform,
         setRunStatus(status)
         getLogger().error(traceback.format_exc())
 
+        # Set result meta and data to default values to that
+        # the reporter will not try to key into a None
+        result = {
+            "meta": {},
+            "data": []
+        }
+
     if data is None or len(data) == 0:
         name = platform.getMangledName()
         model_name = ""


### PR DESCRIPTION
Summary:
Previous result was unset so the reporter woudl try to key into it to get the
data and meta fields leading to an exception

Differential Revision: D17722947

