### PR TITLE
Fix bug with forking test binaries

### DIFF
--- a/benchmarking/utils/subprocess_with_logger.py
+++ b/benchmarking/utils/subprocess_with_logger.py
@@ -12,6 +12,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
+import os
+import signal
 import subprocess
 import sys
 from threading import Timer
@@ -146,7 +148,8 @@ def _Popen(*args, **kwargs):
 
     ps = subprocess.Popen(*args, bufsize=-1, stdout=subprocess.PIPE,
                           stderr=subprocess.STDOUT,
-                          universal_newlines=True, **customArgs)
+                          universal_newlines=True, preexec_fn=os.setsid,
+                          **customArgs)
     # We set the buffer size to system default.
     # this is not really recommended. However, we need to stream the
     # output as they are available. So we do this. But, if the data
@@ -184,7 +187,7 @@ def _getOutput(ps, patterns):
 
 def _kill(p, cmd, processKey):
     try:
-        p.kill()
+        os.killpg(p.pid, signal.SIGKILL)
     except OSError:
         pass  # ignore
     getLogger().error("Process timed out: {}".format(cmd))


### PR DESCRIPTION
Summary:
When benchmarks run under bash they fork additional child processes that must
be killed in order to the benchmark to be timed out. We now start each
subprocess in it's own process group. So all of the child processes of the
benchmark inherit that process group. Then when the benchmark times out we can
kill the entire process group.

Differential Revision: D17726423

