### PR TITLE
Filter out empty metric names in instrumentation output

### DIFF
--- a/benchmarking/frameworks/glow/glow.py
+++ b/benchmarking/frameworks/glow/glow.py
@@ -75,18 +75,23 @@ class GlowFramework(FrameworkBase):
             while line:
                 try:
                     parsed = json.loads(line.rstrip(", \n\t"))
-                    key = "NET " + parsed["name"]
+                    metric = parsed["name"]
+                    if not metric:
+                        raise ValueError("empty metric")
+                    key = "NET " + metric
                     if key in results.keys():
                         results[key]["values"].append(parsed["dur"])
                     else:
                         results[key] = {
                             "type": "NET",
-                            "metric": parsed["name"],
+                            "metric": metric,
                             "unit": "microsecond",
                             "values": [parsed["dur"]]
                         }
                 except json.JSONDecodeError:
                     pass
                 except KeyError:
+                    pass
+                except ValueError:
                     pass
                 line = fp.readline()


### PR DESCRIPTION
Summary: Filter out empty metric names in instrumentation output

Reviewed By: hl475

Differential Revision: D17743007

