### PR TITLE
Add adhoc microbenchmarks

### DIFF
--- a/benchmarking/run_bench.py
+++ b/benchmarking/run_bench.py
@@ -23,7 +23,8 @@ import tempfile
 
 from lab_driver import LabDriver
 from utils.custom_logger import getLogger, setLoggerLevel
-from utils.utilities import getString, getRunStatus, setRunStatus
+from utils.utilities import getString, getRunStatus, setRunStatus, \
+    unpackAdhocFile
 
 
 HOME_DIR = os.path.expanduser('~')
@@ -215,14 +216,17 @@ class RunBench(object):
             benchmark_file = unknowns["-b"]
         # Remove later when adhoc is moved to seperated infrastructure
         if "--adhoc" in unknowns:
-            fd, path = tempfile.mkstemp()
-            with pkg_resources.resource_stream(
-                "aibench",
-                "specifications/models/generic/adhoc.json"
-            ) as stream:
-                with os.fdopen(fd, 'wb') as f:
-                    f.write(stream.read())
-            benchmark_file = path
+            configName = unknowns["--adhoc"]
+            if configName is None:
+                configName = 'generic'
+            adhoc_path, success = unpackAdhocFile(configName)
+            if success:
+                benchmark_file = adhoc_path
+            else:
+                getLogger().error(
+                    "Could not find specified adhoc config: {}"
+                    .format(configName)
+                )
         if not benchmark_file:
             return
 

--- a/benchmarking/utils/utilities.py
+++ b/benchmarking/utils/utilities.py
@@ -21,6 +21,7 @@ from six import string_types
 import sys
 from time import sleep
 import socket
+import tempfile
 import uuid
 
 from .custom_logger import getLogger
@@ -278,3 +279,24 @@ def getMachineId():
     if len(ident) == 0 or ident == 'localhost':
         ident = uuid.uuid1().hex
     return ident
+
+
+adhoc_configs = {
+    'generic': 'specifications/models/generic/adhoc.json',
+    'opbench': 'specifications/models/generic/adhoc_microbenchmarks.json',
+}
+
+
+def unpackAdhocFile(configName='generic'):
+    if configName not in adhoc_configs:
+        return '', False
+
+    fd, path = tempfile.mkstemp()
+    with pkg_resources.resource_stream(
+        'aibench',
+        adhoc_configs[configName]
+    ) as stream:
+        with os.fdopen(fd, 'wb') as f:
+            f.write(stream.read())
+
+    return path, True


### PR DESCRIPTION
Summary:
Users can now specify the flag `--adhoc opbench` which will run the default set
of microoperator benchmarks on aibench and give the user back a link to the
results.

Differential Revision: D17801694

