### PR TITLE
Temporary commit at 10/15/2019, 9:25:35 PM

### DIFF
--- a/benchmarking/driver/benchmark_driver.py
+++ b/benchmarking/driver/benchmark_driver.py
@@ -353,9 +353,14 @@ def _retrieveMeta(info, benchmark, platform, framework, backend, user_identifier
 def _retrieveInfo(info, data):
     if "treatment" in info:
         data["meta"]["treatment_diff"] = info["treatment"].get("diff", "")
+        # For early detection, we have treatment version info.
         data["meta"]["treatment_version"] = info["treatment"].get("version", "")
+        # For post detection, we have treatment commit info.
+        data["meta"]["treatment_commit"] = info["treatment"].get("commit", "")
     if "control" in info and "diff" in info["control"]:
+        # For control, we should always have commit info.
         data["meta"]["control_diff"] = info["control"].get("diff", "")
-        data["meta"]["control_revision"] = info["control"].get("revision", "")
+        data["meta"]["control_commit"] = info["control"].get("commit", "")
+
 
     return data


### PR DESCRIPTION
Summary:
This is a change in order to consolidate D17922360

Our assumption is control is always a committed diff, so we should have diff_number and commit_hash. For treatment, it should have diff_number and commit_hash if it is a post_detection, and diff_number and diff_version.

Differential Revision: D17948428

