### PR TITLE
no print to screen when fetching and no print about meta

### DIFF
--- a/benchmarking/remote/screen_reporter.py
+++ b/benchmarking/remote/screen_reporter.py
@@ -88,6 +88,11 @@ class ScreenReporter(object):
                         if self.debug:
                             self._printLog(r)
                     elif metric == "generic":
+                        if isinstance(data, dict):
+                            if "meta" in data:
+                                del data["meta"]
+                            if not data:
+                                return
                         # dump std printout to screen for custom_binary
                         if isinstance(data, list):
                             data = '\n'.join(data)

--- a/benchmarking/run_remote.py
+++ b/benchmarking/run_remote.py
@@ -552,7 +552,6 @@ class RunRemote(object):
             output = self.db.getBenchmarks(ids)
             self._mobilelabResult(output)
             result = json.dumps(output)
-        print(result)
         return result
 
     def _mobilelabResult(self, output):


### PR DESCRIPTION
Summary:
Two changes:
* When fetch status or result, we don't want the result to print to screen
* When adhoc runs, we don't want meta info to print to screen

Reviewed By: houseroad

Differential Revision: D17962158

