### PR TITLE
add prefix for tempfile and delete all after run

### DIFF
--- a/benchmarking/benchmarks/benchmarks.py
+++ b/benchmarking/benchmarks/benchmarks.py
@@ -128,7 +128,7 @@ class BenchmarkCollector(object):
                     self._getDestFilename(file, model_dir)
                 file["location"] = cached_filename
 
-        tmp_dir = tempfile.mkdtemp()
+        tmp_dir = tempfile.mkdtemp(prefix="aibench")
         for tmp_file in collected_tmp_files:
             tmp_file['location'] = \
                     tmp_file['location'].replace("{TEMPDIR}", tmp_dir)

--- a/benchmarking/harness.py
+++ b/benchmarking/harness.py
@@ -146,7 +146,7 @@ class BenchmarkDriver(object):
         if self.args.reboot:
             platform.rebootDevice()
         for idx in range(len(benchmarks)):
-            tempdir = tempfile.mkdtemp()
+            tempdir = tempfile.mkdtemp(prefix="aibench")
             # we need to get a different framework instance per thread
             # will consolidate later. For now create a new framework
             frameworks = getFrameworks()
@@ -194,7 +194,7 @@ class BenchmarkDriver(object):
                             shutil.rmtree(f["location"], True)
 
     def run(self):
-        tempdir = tempfile.mkdtemp()
+        tempdir = tempfile.mkdtemp(prefix="aibench")
         getLogger().info("Temp directory: {}".format(tempdir))
         info = self._getInfo()
         frameworks = getFrameworks()

--- a/benchmarking/remote/file_handler.py
+++ b/benchmarking/remote/file_handler.py
@@ -52,7 +52,7 @@ class FileHandler(object):
                 getLogger().error("Cannot find {}".format(filename))
             raw_context = pkg_resources.resource_string("aibench", filename)
             temp_name = filename.split("/")[-1]
-            temp_dir = tempfile.mkdtemp()
+            temp_dir = tempfile.mkdtemp(prefix="aibench")
             path = os.path.join(temp_dir, temp_name)
             with open(path, "w") as f:
                 f.write(raw_context.decode("utf-8"))

--- a/benchmarking/reporters/simple_local_reporter/simple_local_reporter.py
+++ b/benchmarking/reporters/simple_local_reporter/simple_local_reporter.py
@@ -39,7 +39,7 @@ class SimpleLocalReporter(ReporterBase):
             id_dir = getFilename(meta["identifier"])
             dirname = os.path.join(self.simple_local_reporter, id_dir)
         else:
-            dirname = tempfile.mkdtemp(dir=self.simple_local_reporter)
+            dirname = tempfile.mkdtemp(dir=self.simple_local_reporter, prefix="aibench")
 
         if os.path.exists(dirname):
             shutil.rmtree(dirname, True)

--- a/benchmarking/run_bench.py
+++ b/benchmarking/run_bench.py
@@ -16,10 +16,7 @@ import argparse
 import copy
 import json
 import os
-import pkg_resources
 import six
-import sys
-import tempfile
 
 from lab_driver import LabDriver
 from utils.custom_logger import getLogger, setLoggerLevel

--- a/benchmarking/run_remote.py
+++ b/benchmarking/run_remote.py
@@ -16,6 +16,7 @@ from __future__ import unicode_literals
 import argparse
 from collections import defaultdict
 from getpass import getuser
+import glob
 import json
 import os
 import pkg_resources
@@ -240,7 +241,7 @@ class RunRemote(object):
                 self.args.job_queue in list_job_queues, \
                 "--job_queue must be choosen from " + " ".join(list_job_queues)
 
-        self.tempdir = tempfile.mkdtemp()
+        self.tempdir = tempfile.mkdtemp(prefix="aibench")
         program_filenames = {}
         if self.args.info:
             self.info = json.loads(self.args.info)
@@ -325,6 +326,18 @@ class RunRemote(object):
             shutil.rmtree(self.tempdir, True)
         if self.args.screen_reporter:
             self._screenReporter(user_identifier)
+
+        # Clean up
+        try:
+            rm_list = glob.glob("/tmp/aibench*")
+            rm_list.extend(glob.iglob("/tmp/aibench*"))
+            for f in rm_list:
+                if os.path.isdir(f):
+                    shutil.rmtree(f, True)
+                if os.path.isfile(f):
+                    os.remove(f)
+        except BaseException:
+            pass
 
     def _updateBenchmarksWithArgs(self, benchmarks, args):
         for benchmark in benchmarks:

--- a/benchmarking/tests/platforms/ios/test_ios_platform.py
+++ b/benchmarking/tests/platforms/ios/test_ios_platform.py
@@ -31,7 +31,7 @@ from platforms.ios.idb import IDB
 
 class IOSPlatformTest(unittest.TestCase):
     def setUp(self):
-        self.tempdir = tempfile.mkdtemp()
+        self.tempdir = tempfile.mkdtemp(prefix="aibench")
         device = {"12345678-9012345678AB901C": "A012BC"}
         idb = IDB(device, self.tempdir)
         with patch("platforms.ios.ios_platform.IOSPlatform.setPlatformHash"),\

--- a/benchmarking/utils/utilities.py
+++ b/benchmarking/utils/utilities.py
@@ -303,7 +303,7 @@ def unpackAdhocFile(configName='generic'):
     if configName not in adhoc_configs:
         return '', False
 
-    fd, path = tempfile.mkstemp()
+    fd, path = tempfile.mkstemp(prefix="aibench")
     with pkg_resources.resource_stream(
         'aibench',
         adhoc_configs[configName]


### PR DESCRIPTION
Summary: We are creating tempfile in multiple places, and it is hard to track them to make sure we delete all of them. Instead, we add prefix so it is easy to find all of them after run.

Differential Revision: D18133160

