### PR TITLE
fix bug in collect result step

### DIFF
--- a/benchmarking/run_lab.py
+++ b/benchmarking/run_lab.py
@@ -301,6 +301,7 @@ class runAsync(object):
         return file_link
 
     def _collectLogData(self, job):
+        res = None
         if job["framework"] == "generic":
             if "control" not in job["benchmarks"]["info"]:
                 res = self._block_from_log(


### PR DESCRIPTION
Summary: `res` has never been declared if we are not using `generic` which cause crushes in LOCK.

Reviewed By: ASankaran

Differential Revision: D18353215

