### PR TITLE
Fix typo when logging warnings

### DIFF
--- a/benchmarking/platforms/platform_base.py
+++ b/benchmarking/platforms/platform_base.py
@@ -171,6 +171,6 @@ class PlatformBase(object):
                     i = i + 1
                 arguments[key] = value
             elif entry != "{program}":
-                getLogger.warning("Failed to get argument {}".format(entry[i]))
+                getLogger().warning("Failed to get argument {}".format(entry[i]))
             i = i + 1
         return arguments


### PR DESCRIPTION
Summary:
```
Exception caught when running benchmark
'function' object has no attribute 'warning'
Traceback (most recent call last):
  File "driver/benchmark_driver.py", line 38, in runOneBenchmark
    data = _runOnePass(minfo, mbenchmark, framework, platform)
  File "driver/benchmark_driver.py", line 106, in _runOnePass
    framework.runBenchmark(info, benchmark, platform)
  File "frameworks/caffe2/caffe2.py", line 39, in runBenchmark
    platform)
  File "frameworks/framework_base.py", line 197, in runBenchmark
    main_command=True)
  File "frameworks/framework_base.py", line 401, in _runCommands
    converter)
  File "frameworks/caffe2/caffe2.py", line 259, in runOnPlatform
    platform_args=platform_args)
  File "platforms/ios/ios_platform.py", line 76, in runBenchmark
    arguments = self.getPairedArguments(cmd)
  File "platforms/platform_base.py", line 174, in getPairedArguments
    getLogger.warning("Failed to get argument {}".format(entry[i]))
AttributeError: 'function' object has no attribute 'warning'
```

Reviewed By: hl475

Differential Revision: D20008831

