### PR TITLE
remove unused import in ios_platform

### DIFF
--- a/benchmarking/platforms/ios/ios_platform.py
+++ b/benchmarking/platforms/ios/ios_platform.py
@@ -18,7 +18,6 @@ import shlex
 import time
 
 from platforms.platform_base import PlatformBase
-from utils.custom_logger import getLogger
 from utils.subprocess_with_logger import processRun
 from utils.utilities import getRunStatus, setRunStatus
 


### PR DESCRIPTION
Summary: `getLogger` is not used in the file

Differential Revision: D20399565

