### PR TITLE
create symlink when file is too large

### DIFF
--- a/benchmarking/benchmarks/benchmarks.py
+++ b/benchmarking/benchmarks/benchmarks.py
@@ -192,8 +192,10 @@ class BenchmarkCollector(object):
 
     def _calculateMD5(self, model_name):
         m = hashlib.md5()
-        m.update(open(model_name, 'rb').read())
+        fo = open(model_name, 'rb')
+        m.update(fo.read())
         md5 = m.hexdigest()
+        fo.close()
         return md5
 
     def _copyFile(self, field, destination_name, source):

--- a/benchmarking/download_benchmarks/download_benchmarks.py
+++ b/benchmarking/download_benchmarks/download_benchmarks.py
@@ -104,8 +104,10 @@ class DownloadBenchmarks(object):
         if os.path.isfile(path):
             if md5:
                 m = hashlib.md5()
-                m.update(open(path, 'rb').read())
+                fo = open(path, 'rb')
+                m.update(fo.read())
                 new_md5 = m.hexdigest()
+                fo.close()
                 if md5 == new_md5:
                     getLogger().info("File {}".format(os.path.basename(path)) +
                         " is cached, skip downloading")

--- a/benchmarking/platforms/host/hdb.py
+++ b/benchmarking/platforms/host/hdb.py
@@ -18,6 +18,8 @@ import shutil
 from platforms.platform_util_base import PlatformUtilBase
 from utils.custom_logger import getLogger
 
+COPY_THRESHOLD = 6442450944  # 6 GB
+
 
 class HDB(PlatformUtilBase):
     def __init__(self, device=None, tempdir=None):
@@ -31,8 +33,11 @@ class HDB(PlatformUtilBase):
                     shutil.rmtree(tgt)
                 shutil.copytree(src, tgt)
             else:
-                shutil.copyfile(src, tgt)
-                os.chmod(tgt, 0o777)
+                if os.stat(src).st_size < COPY_THRESHOLD:
+                    shutil.copyfile(src, tgt)
+                    os.chmod(tgt, 0o777)
+                else:
+                    os.symlink(src, tgt)
 
     def pull(self, src, tgt):
         getLogger().info("pull {} to {}".format(src, tgt))


### PR DESCRIPTION
Summary: AIBench copy files to temp directory after download it and save it to model_cache. This would work find for small files. For large files, copy would also take a lot of time. Instead, we create symlink in this case.

Reviewed By: houseroad

Differential Revision: D20540819

