### PR TITLE
skip upload if from manifold

### DIFF
--- a/benchmarking/remote/file_handler.py
+++ b/benchmarking/remote/file_handler.py
@@ -67,7 +67,7 @@ class FileHandler(object):
                 os.path.dirname(os.path.realpath(basefilename)),
                 filename)
 
-        if not os.path.isfile(path):
+        if not os.path.isfile(path) or filename.startswith("//manifold"):
             getLogger().info("Skip uploading {}".format(filename))
             return filename, md5
 


### PR DESCRIPTION
Summary: If a file is saving under manifold instead of everstore, aibench will upload it to everstore due to there is only `--file_storage` at a time. The quick solution is introduced in this diff.

Differential Revision: D20805065

