### PR TITLE
add p to indicate percentile

### DIFF
--- a/benchmarking/frameworks/glow/glow.py
+++ b/benchmarking/frameworks/glow/glow.py
@@ -86,14 +86,18 @@ class GlowFramework(FrameworkBase):
                     )
                     if match:
                         unit = match.group(1)
-                        percentile = match.group(2)
+                        percentile = "p" + match.group(2)
                         value = float(match.group(3))
 
                         self._addOrAppendResult(results,
-                            " ".join([mtype, name, "net_runner", latency_kind, percentile]),
+                            " ".join(
+                                [mtype, name, "net_runner", latency_kind, percentile]
+                            ),
                             value, {
                                 "type": mtype,
-                                "metric": " ".join([name, "net_runner", latency_kind, percentile]),
+                                "metric": " ".join(
+                                    [name, "net_runner", latency_kind, percentile]
+                                ),
                                 "unit": unit,
                                 "values": []
                             }


### PR DESCRIPTION
Summary: From results, the metric name has just numeric and it is very misleading.

Reviewed By: houseroad

Differential Revision: D20970825

