### PR TITLE
do not remove model files after run

### DIFF
--- a/benchmarking/run_lab.py
+++ b/benchmarking/run_lab.py
@@ -259,13 +259,16 @@ class runAsync(object):
 
     def _removeBenchmarkFiles(self, device):
         benchmark_file = self.job["benchmarks"]["benchmark"]["content"]
-        models_location = self.job["models_location"]
+        # models_location = self.job["models_location"]
         programs_location = self.job["programs_location"]
         output_dir = device["output_dir"]
 
         os.remove(benchmark_file)
-        for model_location in models_location:
-            shutil.rmtree(os.path.dirname(model_location), True)
+        # We don't delete files from models_location because after each run
+        # to save model re-download time. This might be a problem to have
+        # many files saving on the disk and many disk spaces used.
+        # for model_location in models_location:
+        #     shutil.rmtree(os.path.dirname(model_location), True)
         for program_location in programs_location:
             shutil.rmtree(os.path.dirname(program_location), True)
         shutil.rmtree(output_dir, True)


### PR DESCRIPTION
Summary:
The way how aibench download work is
* first download all model files (everstore, manifold, etc) to `models_location` (root_model_dir)
* create copy from root_model_dir to model_cache_dir
* create copy from model_cache_dir to some temp_dir

After the run, the cleanup step will delete temp_dir, model_location.

In my previous diff which creates sys link, the source file is in model_location. Files from model_cache_dir, and temp_dir will linked to the source file. Now model_location is deleted after the run, so the link does not work any more. Instead, it will do the download one more time.

Put it as comments in the code to remind this place might be revisited...

Differential Revision: D21002560

