### PR TITLE
bug fix when parsing output from glow net runner

### DIFF
--- a/benchmarking/frameworks/glow/glow.py
+++ b/benchmarking/frameworks/glow/glow.py
@@ -103,7 +103,8 @@ class GlowFramework(FrameworkBase):
                             }
                         )
                     i += 1
-            i += 1
+            else:
+                i += 1
 
     def _maybeAddJsonOutput(self, output, results):
         if output is None:


### PR DESCRIPTION
Summary: Previously, we always do i += 1 in the while loop. This will result i += 2 in some case (line 105 and 106). Some output will get skipped in this case.

Differential Revision: D21044696

