### PR TITLE
memory efficient way to calculate md5 for large file

### DIFF
--- a/benchmarking/platforms/host/hdb.py
+++ b/benchmarking/platforms/host/hdb.py
@@ -37,7 +37,8 @@ class HDB(PlatformUtilBase):
                     shutil.copyfile(src, tgt)
                     os.chmod(tgt, 0o777)
                 else:
-                    os.symlink(src, tgt)
+                    if not os.path.isfile(tgt):
+                        os.symlink(src, tgt)
 
     def pull(self, src, tgt):
         getLogger().info("pull {} to {}".format(src, tgt))


### PR DESCRIPTION
Summary:
There were multi places in aibench to calculate md5sum of files.

For small files, this is ok but not ok if we are reading large files and hosts does not have enough memory to fit the whole file.

This diff change the way to load the file chunk by chunk, and only calculate md5sum once for large file per run.

Differential Revision: D21050879

