### PR TITLE
Add garbage collection explicitly into aibench

### DIFF
--- a/benchmarking/benchmarks/benchmarks.py
+++ b/benchmarking/benchmarks/benchmarks.py
@@ -196,8 +196,11 @@ class BenchmarkCollector(object):
         return False
 
     def _calculateMD5(self, model_name, old_md5, filename):
-        if os.stat(filename).st_size >= COPY_THRESHOLD:
+        if os.stat(filename).st_size >= COPY_THRESHOLD or os.path.islink(model_name):
             if not os.path.isfile(model_name):
+                getLogger().info(
+                    "Create symlink between {} and {}".format(filename, model_name)
+                )
                 os.symlink(filename, model_name)
             return old_md5
         getLogger().info("Calculate md5 of {}".format(model_name))
@@ -227,6 +230,10 @@ class BenchmarkCollector(object):
                     shutil.copyfile(abs_name, destination_name)
                 else:
                     if not os.path.isfile(destination_name):
+                        getLogger().info(
+                            "Create symlink between {} and {}".format(
+                                abs_name, destination_name)
+                        )
                         os.symlink(abs_name, destination_name)
             else:
                 import distutils.dir_util

--- a/benchmarking/driver/benchmark_driver.py
+++ b/benchmarking/driver/benchmark_driver.py
@@ -13,6 +13,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 import copy
+import gc
 import os
 import sys
 import time
@@ -37,6 +38,7 @@ def runOneBenchmark(info, benchmark, framework, platform,
     try:
         # invalidate CPU cache
         [1.0 for _ in range(20 << 20)]
+        gc.collect()
         data = _runOnePass(minfo, mbenchmark, framework, platform)
         status = status | getRunStatus()
         meta = None
@@ -50,6 +52,7 @@ def runOneBenchmark(info, benchmark, framework, platform,
             time.sleep(cooldown)
             # invalidate CPU cache
             [1.0 for _ in range(20 << 20)]
+            gc.collect()
             control = _runOnePass(cinfo, benchmark, framework, platform)
             status = status | getRunStatus()
             bname = benchmark["model"]["name"]

--- a/benchmarking/platforms/host/hdb.py
+++ b/benchmarking/platforms/host/hdb.py
@@ -38,6 +38,9 @@ class HDB(PlatformUtilBase):
                     os.chmod(tgt, 0o777)
                 else:
                     if not os.path.isfile(tgt):
+                        getLogger().info(
+                            "Create symlink between {} and {}".format(src, tgt)
+                        )
                         os.symlink(src, tgt)
 
     def pull(self, src, tgt):

--- a/benchmarking/run_lab.py
+++ b/benchmarking/run_lab.py
@@ -16,6 +16,7 @@ from __future__ import unicode_literals
 
 import argparse
 import datetime
+import gc
 import glob
 from io import StringIO
 import json
@@ -283,6 +284,7 @@ class runAsync(object):
                     shutil.rmtree(f, True)
                 if os.path.isfile(f):
                     os.remove(f)
+            gc.collect()
         except BaseException:
             pass
 
@@ -661,6 +663,7 @@ class RunLab(object):
                 getLogger().error(e)
                 getLogger().error("Terminating...")
                 os._exit(1)
+            gc.collect()
 
     def _getDevices(self):
         raw_args = []


### PR DESCRIPTION
Summary:
We add `gc.collect() ` into the place
* after download the file
* before treatment run
* before control run
* after deleting temp files

Differential Revision: D21083354

