### PR TITLE
change db post failed log from error to warning

### DIFF
--- a/benchmarking/bridge/db.py
+++ b/benchmarking/bridge/db.py
@@ -147,7 +147,7 @@ class DBDriver(object):
         result_json = requestsJson(self.benchmark_db_entry,
                                    data=params, timeout=NETWORK_TIMEOUT)
         if "status" not in result_json or result_json['status'] != "success":
-            getLogger().error(
+            getLogger().warning(
                 "DB post failed, params {}".format(json.dumps(params)))
             return {
                 "status": "fail",


### PR DESCRIPTION
Summary: `error` in log is misleading us to debug. Let's change it to `warning` now

Differential Revision: D21560475

