### PR TITLE
adding errors processing in Popen

### DIFF
--- a/benchmarking/utils/subprocess_with_logger.py
+++ b/benchmarking/utils/subprocess_with_logger.py
@@ -184,6 +184,7 @@ def _Popen(*args, **kwargs):
     ps = subprocess.Popen(*args, bufsize=-1, stdout=subprocess.PIPE,
                           stderr=subprocess.STDOUT,
                           universal_newlines=True, preexec_fn=os.setsid,
+                          errors="replace",
                           **customArgs)
     # We set the buffer size to system default.
     # this is not really recommended. However, we need to stream the


### PR DESCRIPTION
Summary: This prevents Unicode Errors when parsing output from some command runs.

Reviewed By: hl475

Differential Revision: D23569833

