### PR TITLE
Update docker_tflite.sh

### DIFF
--- a/specifications/docker/docker_tflite.sh
+++ b/specifications/docker/docker_tflite.sh
@@ -59,15 +59,11 @@ echo "
 # clone/install tflite
 
 apt-get install wget pkg-config g++ zlib1g-dev python zip unzip -y
-if [ ! -z ${BAZEL_DIR} ]; then
-  mkdir -p ${BAZEL_DIR}
-fi
-if [ ! -f ${BAZEL_DIR}/${BAZEL} ]; then
-  wget -q -O ${BAZEL_DIR}/${BAZEL} https://github.com/bazelbuild/bazel/releases/download/0.25.0/${BAZEL}
-fi
-chmod +x ${BAZEL_DIR}/${BAZEL}
-${BAZEL_DIR}/${BAZEL} --user
-export PATH="$PATH:$HOME/bin"
+
+echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
+curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
+apt-get update
+apt-get install bazel-3.1.0
 
 rm -rf ${REPO_DIR}
 git clone --recursive --quiet https://github.com/tensorflow/tensorflow.git "$REPO_DIR"


### PR DESCRIPTION
bazel version 0.25.0 fails to run 
"bazel build -c opt ${LINKER_OPTS} \
  tensorflow/lite/tools/benchmark:benchmark_model" command in specifications/frameworks/tflite/host/build.sh with message
"Unrecognized option: --experimental_repo_remote_exec"

Actually, tflite requires 3.1.0 explicitly.