### PR TITLE
Fix string interpolation bug

### DIFF
--- a/benchmarking/utils/build_program.py
+++ b/benchmarking/utils/build_program.py
@@ -87,7 +87,7 @@ def _readFromPath(framework, frameworks_dir, platform, dst):
                             + "doesn't exist. Use "
                             + "{} instead".format(framework_dir))
     assert os.path.isfile(build_script), \
-        "Cannot find build script in {} for ".framework_dir + \
+        "Cannot find build script in {} for ".format(framework_dir) + \
         "platform {}".format(platform)
 
     return build_script


### PR DESCRIPTION
Summary: String has no method `.framework_dir`. Someone missed `.format`

Reviewed By: kimishpatel

Differential Revision: D25879605

