### PR TITLE
Fix _getDevices for ios and moves "silent" to kwargs

### DIFF
--- a/benchmarking/platforms/ios/ios_driver.py
+++ b/benchmarking/platforms/ios/ios_driver.py
@@ -29,9 +29,9 @@ class IOSDriver(object):
         self.devices = devices
         self.type = "ios"
 
-    def getDevices(self):
+    def getDevices(self, silent=False):
         idb = IDB()
-        rows = idb.run("--detect")
+        rows = idb.run("--detect", silent=silent)
         if len(rows) == 0:
             return {}
         rows.pop(0)

--- a/benchmarking/platforms/platforms.py
+++ b/benchmarking/platforms/platforms.py
@@ -39,7 +39,7 @@ def getPlatforms(args, tempdir="/tmp"):
         getLogger().error("No platform or physical device detected.")
     return platforms
 
-def getDeviceList(args, tempdir="/tmp", silent=False):
+def getDeviceList(args, silent=False):
     assert args.platform in ("android","ios"), "This is only supported for mobile platforms."
     deviceList = []
     if args.platform.startswith("android"):
@@ -47,7 +47,7 @@ def getDeviceList(args, tempdir="/tmp", silent=False):
         deviceList.extend(driver.getDevices(silent))
     elif args.platform.startswith("ios"):
         driver = IOSDriver(args)
-        deviceList.extend(driver.getDevices(tempdir, silent))
+        deviceList.extend(driver.getDevices(silent))
     return deviceList
 
 def getHostPlatform(tempdir, args):


### PR DESCRIPTION
Summary: Fixes an bug with device monitor where getDevices had the wrong number of arguments for ios.  "silent" property is now in both and passed through kwargs.

Reviewed By: axitkhurana

Differential Revision: D27443852

