### PR TITLE
Fix iOS driver set error when providing device.

### DIFF
--- a/benchmarking/platforms/ios/ios_driver.py
+++ b/benchmarking/platforms/ios/ios_driver.py
@@ -70,10 +70,9 @@ class IOSDriver(object):
                 self.devices = supported_devices
 
         for device in self.devices:
-            model = self.devices[device]
             idb = IDB(device, tempdir)
             platform = IOSPlatform(tempdir, idb, self.args)
-            platform.setPlatform(model)
+            platform.setPlatform(device)
             platforms.append(platform)
 
         return platforms


### PR DESCRIPTION
Summary: This change is required to fix an error where new devices detected by device monitor were passed in as a list to instantiate the platform.  This was causing a "cannot index on set" error from the removed line.  Platform should be instantiated by its hash, which is passed as the device argument.

Differential Revision: D27634546

