### PR TITLE
Closed file in _calculateMD5 in file_handler.py to remove ResourceWarning

### DIFF
--- a/benchmarking/remote/file_handler.py
+++ b/benchmarking/remote/file_handler.py
@@ -107,7 +107,8 @@ class FileHandler(object):
 
     def _calculateMD5(self, filename):
         m = hashlib.md5()
-        m.update(open(filename, 'rb').read())
+        with open(filename, 'rb') as f:
+            m.update(f.read())
         md5 = m.hexdigest()
         return md5
 


### PR DESCRIPTION
Summary: Closes file to eliminate ResourceWarning.

Reviewed By: axitkhurana

Differential Revision: D28582522

