### PR TITLE
Write logs to separate files when multiple devices used

### DIFF
--- a/benchmarking/run_remote.py
+++ b/benchmarking/run_remote.py
@@ -62,8 +62,8 @@ parser.add_argument("--hashes", default=None,
     "together with --remote and --devices")
 parser.add_argument("--debug", action="store_true",
             help="Debug mode to retain all the running binaries and models.")
-parser.add_argument("--log_output_path", default=None,
-    help="Path where the benchmark logs are written to. If not specified, the logs are outputted to the terminal")
+parser.add_argument("--log_output_dir", default=None,
+    help="Directory where the benchmark logs are written to. If not specified, the logs are outputted to the terminal")
 parser.add_argument("--devices",
     help="Specify the devices to benchmark on, in comma separated list.")
 parser.add_argument("--devices_config", default=None,
@@ -568,7 +568,7 @@ class RunRemote(object):
                 self.args.urlPrefix, user_identifier))
 
     def _screenReporter(self, user_identifier):
-        reporter = ScreenReporter(self.db, self.devices, self.args.debug, self.args.log_output_path)
+        reporter = ScreenReporter(self.db, self.devices, self.args.debug, self.args.log_output_dir)
         reporter.run(user_identifier)
 
     def _fetchResult(self):


### PR DESCRIPTION
Summary:
- Address comments from D28517101 (https://github.com/facebook/FAI-PEP/commit/b70399db7c44301cdd036448010ffb9c044b6dfe)
- Change arg to 'log_output_dir', so the user can now specify the output directory. The file name is determined from the name of the device.
- Move logic to output logs to file to `_printLog()` - this will ensure that logs are written even when the run fails, making debugging easier.
- Ensure that logs don't get overwritten when multiple devices are specified in the runs.
   - Append device name to output directory in order to generate a new log file for each benchmark run

Differential Revision: D28578326

