### PR TITLE
Fix bug where program arguments could throw index error if a store true was trailing

### DIFF
--- a/benchmarking/platforms/platform_base.py
+++ b/benchmarking/platforms/platform_base.py
@@ -199,7 +199,7 @@ class PlatformBase(object):
             entry = cmd[i]
             if entry[:2] == "--":
                 key = entry[2:]
-                value = cmd[i+1] if i < len(cmd) else "true"
+                value = cmd[i+1] if i < len(cmd) - 1 else "true"
                 if value[:2] == "--":
                     value = "true"
                 else:


### PR DESCRIPTION
Summary: Program arguments with a store true value at the end throw an index exception due to setting value to the next position, for all i up until len.  Using len - 1 will allow value to be set correctly otherwise store true, in all cases.

Reviewed By: rashirungta

Differential Revision: D28853131

