### PR TITLE
Update IOSDriver to check devices silently by default, set retries for iOS and Android to 1

### DIFF
--- a/benchmarking/platforms/android/android_driver.py
+++ b/benchmarking/platforms/android/android_driver.py
@@ -28,9 +28,9 @@ class AndroidDriver:
         self.devices = devices
         self.type = "android"
 
-    def getDevices(self, silent=False):
+    def getDevices(self, silent=False, retry=1):
         adb = ADB()
-        rows = adb.run("devices", "-l", silent=silent)
+        rows = adb.run("devices", "-l", silent=silent, retry=1)
         rows.pop(0)
         devices = set()
         for row in rows:

--- a/benchmarking/platforms/ios/ios_driver.py
+++ b/benchmarking/platforms/ios/ios_driver.py
@@ -30,9 +30,9 @@ class IOSDriver(object):
             self.devices = {d: self.devices[d] for d in self.devices if d in devices}
         self.type = "ios"
 
-    def getDevices(self, silent=False):
+    def getDevices(self, silent=True, retry=1):
         idb = IDB()
-        rows = idb.run(["--detect", "--timeout", "1"], silent=silent)
+        rows = idb.run(["--detect", "--timeout", "1"], silent=silent, retry=1)
         if len(rows) == 0:
             return {}
         rows.pop(0)

--- a/benchmarking/platforms/platforms.py
+++ b/benchmarking/platforms/platforms.py
@@ -39,15 +39,15 @@ def getPlatforms(args, tempdir="/tmp", usb_controller=None):
         getLogger().error("No platform or physical device detected.")
     return platforms
 
-def getDeviceList(args, silent=False):
+def getDeviceList(args, silent=False, retry=1):
     assert args.platform in ("android","ios"), "This is only supported for mobile platforms."
     deviceList = []
     if args.platform.startswith("android"):
         driver = AndroidDriver(args)
-        deviceList.extend(driver.getDevices(silent))
+        deviceList.extend(driver.getDevices(silent, retry))
     elif args.platform.startswith("ios"):
         driver = IOSDriver(args)
-        deviceList.extend(driver.getDevices(silent))
+        deviceList.extend(driver.getDevices(silent, retry))
     return deviceList
 
 def getHostPlatform(tempdir, args):


### PR DESCRIPTION
Summary: Update _checkDevices function to perform silently by default for device monitor thread, set retry to 1 to avoid extra logging/function calls.

Reviewed By: axitkhurana

Differential Revision: D29316930

