### PR TITLE
Wrap download call in lock to fix possible file exist error

### DIFF
--- a/benchmarking/run_lab.py
+++ b/benchmarking/run_lab.py
@@ -195,7 +195,8 @@ class runAsync(object):
             getLogger().info("Realtime logging enabled with {}s updates.".format(self.args.rt_logging_interval))
         try:
             self._setFramework()
-            self._downloadFiles()
+            with LOCK:
+                self._downloadFiles()
             raw_args = self._getRawArgs()
             app = BenchmarkDriver(raw_args=raw_args, usb_controller=self.usb_controller)
             getLogger().debug(f"Running BenchmarkDriver for benchmark {self.job['identifier']} id ({self.job['id']})")


### PR DESCRIPTION
Summary: Fixes a bug where running benchmark on multiple devices could cause a file exists error when downloading files.  Download function is wrapped in lock to allow downloads to run serially as before.

Reviewed By: axitkhurana

Differential Revision: D30170167

