### PR TITLE
Handle cv==None in _createDiffOfDelay()

### DIFF
--- a/benchmarking/driver/benchmark_driver.py
+++ b/benchmarking/driver/benchmark_driver.py
@@ -237,18 +237,21 @@ def _percentileArgVal(token) -> float:
 def _createDiffOfDelay(csummary, tsummary):
     # create diff of delay
     diff_summary = {}
-    for value in tsummary:
-        arg = _percentileArgVal(value)
+    for key in tsummary:
+        if tsummary[key] is None:
+            continue
+
+        arg = _percentileArgVal(key)
         if arg is not None:
             if arg == int(arg):
                 reflection = "p" + str(100 - int(arg))
             else:
                 reflection = "p" + str(100.0 - arg)
 
-            if reflection in csummary:
-                diff_summary[value] = tsummary[value] - csummary[reflection]
-        elif value in csummary:
-            diff_summary[value] = tsummary[value] - csummary[value]
+            if reflection in csummary and csummary[reflection] is not None:
+                diff_summary[key] = round(tsummary[key] - csummary[reflection], 15)
+        elif key in csummary and csummary[key] is not None:
+            diff_summary[key] = round(tsummary[key] - csummary[key], 15)
 
     return diff_summary
 

--- a/benchmarking/tests/test_run_bench/test_benchmark_driver.py
+++ b/benchmarking/tests/test_run_bench/test_benchmark_driver.py
@@ -25,6 +25,8 @@ class BenchmarkDriverUnitTest(unittest.TestCase):
 
     array2 = [4.0, 3.0, 2.0, 1.0, 0.0]
 
+    array_with_zero_mean = [-2.0, -1.0, 0.0, 1.0, 2.0]
+
     expected1 = {
         "mean": 2.0,
         "p0": 0.0,
@@ -49,11 +51,28 @@ class BenchmarkDriverUnitTest(unittest.TestCase):
         "cv": 0.7071067811865476,
     }
 
+    result_with_cv_none = {
+        "mean": 0.0,
+        "p0": -2.0,
+        "p10": -1.6,
+        "p50": 0.0,
+        "p90": 1.6,
+        "p100": 2.0,
+        "stdev": 1.4142135623730951,
+        "MAD": 1.0,
+        "cv": None,
+    }
+
     def test_getStatistics1(self):
         self.assertEqual(bd._getStatistics(self.array1), self.expected1)
 
     def test_getStatistics2(self):
         self.assertEqual(bd._getStatistics(self.array2), self.expected2)
+
+    def test_getStatistics_with_zero_mean(self):
+        self.assertEqual(
+            bd._getStatistics(self.array_with_zero_mean), self.result_with_cv_none
+        )
 
     def test_getStatistics_custom_valid(self):
         stats = ["p10", "p90", "p50", "p95", "p5", "p11"]
@@ -119,6 +138,40 @@ class BenchmarkDriverUnitTest(unittest.TestCase):
 
         self.assertEqual(
             bd._createDiffOfDelay(self.expected1, self.expected1), expectedDiff
+        )
+
+    def test_createDiffOfDelay_None1(self):
+        expectedDiff = {
+            "mean": 2.0,
+            "p0": -2.0,
+            "p10": -1.2,
+            "p50": 2.0,
+            "p90": 5.2,
+            "p100": 6.0,
+            "stdev": 0.0,
+            "MAD": 0.0,
+        }
+
+        self.assertEqual(
+            bd._createDiffOfDelay(self.result_with_cv_none, self.expected1),
+            expectedDiff,
+        )
+
+    def test_createDiffOfDelay_None2(self):
+        expectedDiff = {
+            "mean": -2.0,
+            "p0": -6.0,
+            "p10": -5.2,
+            "p50": -2.0,
+            "p90": 1.2,
+            "p100": 2.0,
+            "stdev": 0.0,
+            "MAD": 0.0,
+        }
+
+        self.assertEqual(
+            bd._createDiffOfDelay(self.expected1, self.result_with_cv_none),
+            expectedDiff,
         )
 
     def test_getPercentile_EmptyError(self):


### PR DESCRIPTION
Summary:
Handle the case where cv==None in results which were causing the diff results to fail.

Also do some code cleanup and add unit tests.

round(a - b) is necessary to get correct / predictable results due to known "limitations" of Python's float implementation.

For example:
1.6 - 0.4 gives 1.2000000000000002 without rounding.

Therefore the last decimal place is not reliable.

Reviewed By: axitkhurana

Differential Revision: D31565024

