### PR TITLE
AIBench FBCode: Add critical log statements to generate alerts

### DIFF
--- a/benchmarking/driver/benchmark_driver.py
+++ b/benchmarking/driver/benchmark_driver.py
@@ -73,15 +73,16 @@ def runOneBenchmark(
         )
         data = _retrieveInfo(info, data)
         result = {"meta": meta, "data": data}
-    except Exception as e:
+    except Exception:
         # Catch all exceptions so that failure in one test does not
         # affect other tests
-        getLogger().info("Exception caught when running benchmark")
-        getLogger().info(e)
+        getLogger().critical(
+            "Exception caught when running benchmark.",
+            exc_info=True,
+        )
         data = None
         status = 2
         setRunStatus(status)
-        getLogger().error(traceback.format_exc())
 
         # Set result meta and data to default values to that
         # the reporter will not try to key into a None
@@ -177,8 +178,7 @@ def _mergeDelayData(treatment_data, control_data, bname):
             continue
         if k not in control_data:
             getLogger().error(
-                "Value {} existed in treatment but not ".format(k)
-                + "control for benchmark {}".format(bname)
+                f"Value {k} existed in treatment but not control for benchmark {bname}.",
             )
             continue
         control_value = control_data[k]
@@ -260,9 +260,8 @@ def _mergeDelayMeta(treatment_meta, control_meta, bname):
     meta = copy.deepcopy(treatment_meta)
     for k in treatment_meta:
         if k not in control_meta:
-            getLogger().error(
-                "Value {} existed in treatment but not ".format(k)
-                + "control for benchmark {}".format(bname)
+            getLogger().critical(
+                f"Value {k} existed in treatment but not control for benchmark {bname}."
             )
             continue
         meta["control_{}".format(k)] = control_meta[k]

--- a/benchmarking/frameworks/framework_base.py
+++ b/benchmarking/frameworks/framework_base.py
@@ -580,7 +580,7 @@ class FrameworkBase(object):
             info_string_map = (
                 json.loads(stringmap_from_info) if stringmap_from_info else {}
             )
-        except BaseException:
+        except Exception:
             string_map = (
                 ast.literal_eval(self.args.string_map) if self.args.string_map else {}
             )

--- a/benchmarking/platforms/android/adb.py
+++ b/benchmarking/platforms/android/adb.py
@@ -41,9 +41,11 @@ class ADB(PlatformUtilBase):
         try:
             self.run("reboot")
             return True
-        except Exception as e:
-            getLogger().error("Rebooting failure...")
-            getLogger().error("Unknown exception {}".format(e))
+        except Exception:
+            getLogger().critical(
+                f"Rebooting failure for device {self.device_kind} {self.device_hash}.",
+                exc_info=True,
+            )
             return False
 
     def root(self, silent=False):

--- a/benchmarking/platforms/android/android_platform.py
+++ b/benchmarking/platforms/android/android_platform.py
@@ -264,9 +264,10 @@ class AndroidPlatform(PlatformBase):
                             log_logcat = self.util.logcat("-d")
                         return output + log_logcat, meta
                 # if this has not succeeded for some reason reset run status and run without profiling.
-                except Exception as ex:
-                    getLogger().exception(
-                        f"An error has occurred when running Simpleperf profiler. {ex}"
+                except Exception:
+                    getLogger().critical(
+                        f"An error has occurred when running Simpleperf profiler on device {self.platform}  {self.platform_hash}.",
+                        exc_info=True,
                     )
         log_screen = self.util.shell(cmd, **platform_args)
         log_logcat = []
@@ -305,10 +306,8 @@ class AndroidPlatform(PlatformBase):
             ls = self.util.shell(["ls", self.tgt_dir])
             time.sleep(period)
         if len(ls) == 0:
-            getLogger().error(
-                "Cannot reach device {} ({}) after {}.".format(
-                    self.platform, self.platform_hash, timeout
-                )
+            getLogger().critical(
+                f"Cannot reach device {self.platform} {self.platform_hash} after {timeout}s."
             )
 
     def currentPower(self):
@@ -319,7 +318,10 @@ class AndroidPlatform(PlatformBase):
                     result_line = line
             return int(result_line.split(": ")[-1])
         except Exception:
-            getLogger().exception("Could not read battery level")
+            getLogger().critical(
+                f"Could not read battery level for device {self.platform}  {self.platform_hash}",
+                exc_info=True,
+            )
             return -1
 
     @property

--- a/benchmarking/platforms/ios/idb.py
+++ b/benchmarking/platforms/ios/idb.py
@@ -69,8 +69,10 @@ class IDB(PlatformUtilBase):
             super(IDB, self).run("idevicediagnostics", "-u", self.device, "restart")
             return True
         except Exception:
-            getLogger().error("Rebooting failure...")
-            getLogger().error("Unknown exception {}".format(sys.exc_info()[0]))
+            getLogger().critical(
+                f"Rebooting failure for device {self.device_kind} {self.device_hash}.",
+                exc_info=True,
+            )
             return False
 
     def deleteFile(self, file):
@@ -88,5 +90,8 @@ class IDB(PlatformUtilBase):
             getLogger().info("Result {}".format(level))
             return level
         except Exception:
-            getLogger().exception("Could not read battery level")
+            getLogger().critical(
+                f"Could not read battery level for device {self.device_kind} {self.device_hash}.",
+                exc_info=True,
+            )
             return -1

--- a/benchmarking/platforms/ios/ios_platform.py
+++ b/benchmarking/platforms/ios/ios_platform.py
@@ -131,11 +131,11 @@ class IOSPlatform(PlatformBase):
                     if not output or not meta:
                         raise RuntimeError("No data returned from XCTrace profiler.")
                     return output, meta
-            except Exception as ex:
-                getLogger().exception(
-                    f"An error occurred when running XCTrace profiler. {ex}"
+            except Exception:
+                getLogger().critical(
+                    f"An error occurred when running XCTrace profiler on device {self.platform} {self.platform_hash}.",
+                    exc_info=True,
                 )
-
         # meta is used to store any data about the benchmark run
         # that is not the output of the command
         meta = {}

--- a/benchmarking/platforms/platform_base.py
+++ b/benchmarking/platforms/platform_base.py
@@ -59,7 +59,7 @@ class PlatformBase(object):
                 )
 
                 self.hash_platform_mapping = hash_platform_mapping
-            except BaseException:
+            except Exception:
                 pass
 
         if isinstance(device_name_mapping, string_types):
@@ -79,7 +79,7 @@ class PlatformBase(object):
                 )
 
                 self.device_name_mapping = device_name_mapping
-            except BaseException:
+            except Exception:
                 pass
 
     def getType(self):

--- a/benchmarking/platforms/platforms.py
+++ b/benchmarking/platforms/platforms.py
@@ -40,7 +40,7 @@ def getPlatforms(args, tempdir="/tmp", usb_controller=None):
     elif os.name == "nt":
         platforms.append(WindowsPlatform(tempdir))
     if not platforms:
-        getLogger().error("No platform or physical device detected.")
+        getLogger().warning("No platform or physical device detected.")
     return platforms
 
 

--- a/benchmarking/regression_detectors/regression_detectors.py
+++ b/benchmarking/regression_detectors/regression_detectors.py
@@ -136,9 +136,7 @@ def _getLatestRun(dir):
     if last_run >= 0:
         return os.path.join(dir, str(last_run))
     else:
-        getLogger().error(
-            "Latest run in directory %s doesn't exist. " "This should not happen." % dir
-        )
+        getLogger().critical(f"Latest run in directory {dir} doesn't exist.")
         return None
 
 

--- a/benchmarking/repo_driver.py
+++ b/benchmarking/repo_driver.py
@@ -172,7 +172,7 @@ class ExecutablesBuilder(threading.Thread):
                 self._buildExecutables()
         except Exception:
             setRunStatus(2)
-            getLogger().error(traceback.format_exc())
+            getLogger().exception("Error building executable.")
 
     def _buildExecutables(self):
         platforms = self.args.platforms.split(",")

--- a/benchmarking/reporters/remote_reporter/remote_reporter.py
+++ b/benchmarking/reporters/remote_reporter/remote_reporter.py
@@ -118,7 +118,7 @@ class RemoteReporter(ReporterBase):
                 value = int(meta[key])
                 meta.pop(key, None)
                 summary[key] = value
-            except BaseException:
+            except Exception:
                 getLogger().warning("{} cannot be converted into int".format(meta[key]))
                 pass
 

--- a/benchmarking/run_remote.py
+++ b/benchmarking/run_remote.py
@@ -454,7 +454,7 @@ class RunRemote(object):
                     shutil.rmtree(f, True)
                 if os.path.isfile(f):
                     os.remove(f)
-        except BaseException:
+        except Exception:
             pass
 
     def _updateBenchmarksWithArgs(self, benchmarks, args):

--- a/benchmarking/utils/build_program.py
+++ b/benchmarking/utils/build_program.py
@@ -77,7 +77,7 @@ def getBuildScript(framework, frameworks_dir, platform, dst):
     if not frameworks_dir:
         try:
             build_script = _readFromBinary(framework, frameworks_dir, platform, dst)
-        except BaseException as e:
+        except Exception as e:
             getLogger().info("We will load from old default path due to {}.".format(e))
             frameworks_dir = str(
                 os.path.dirname(os.path.realpath(__file__))
@@ -87,7 +87,7 @@ def getBuildScript(framework, frameworks_dir, platform, dst):
     else:
         try:
             build_script = _readFromPath(framework, frameworks_dir, platform, dst)
-        except BaseException as e:
+        except Exception as e:
             getLogger().info("We will load from binary due to {}.".format(e))
             build_script = _readFromBinary(framework, frameworks_dir, platform, dst)
 

--- a/benchmarking/utils/log_update_handler.py
+++ b/benchmarking/utils/log_update_handler.py
@@ -70,14 +70,14 @@ class DBLogUpdateHandler(logging.Handler):
                         self.retries_left -= 1
                         if self.retries_left == 0:
                             self.running = False
-                            getLogger().error(
+                            getLogger().critical(
                                 "Max failed attempts reached for log updates. Stopping log update requests."
                             )
                     else:
                         self.retries_left = self.retries
                     self.lastreq = time.time()
-                except Exception as ex:
-                    getLogger().error(ex)
+                except Exception:
+                    getLogger().exception("Error occurred in realtime logging loop.")
                     self.running = False
             time.sleep(1)
 

--- a/benchmarking/utils/log_utils.py
+++ b/benchmarking/utils/log_utils.py
@@ -35,8 +35,11 @@ def valid_interval(arg) -> int:
 
 
 def trimLog(output):
-    if sys.getsizeof(output) > LOG_LIMIT:
-        getLogger().error("Error, output is too large")
+    output_size = sys.getsizeof(output)
+    if output_size > LOG_LIMIT:
+        getLogger().warning(
+            f"Output size {output_size} is over the log limit of {LOG_LIMIT} and will be trimmed."
+        )
         output = output[-LOG_LIMIT:]
     return output
 


### PR DESCRIPTION
Summary: Adds critical logging statements for errors which should notify AIBench oncall. Logging from exceptions should include "exc_info=True" to capture traceback information.  Also updates except blocks with BaseException to Exception to avoid catching kb interrupts or system terminations.

Reviewed By: axitkhurana

Differential Revision: D31568184

