### PR TITLE
Fix scuba regression due to custom statistics

### DIFF
--- a/benchmarking/driver/benchmark_driver.py
+++ b/benchmarking/driver/benchmark_driver.py
@@ -440,7 +440,6 @@ def _retrieveMeta(info, benchmark, platform, framework, backend, user_identifier
 
     # test specific
     test = benchmark["tests"][0]
-    meta["statistics"] = _getStatisticsSet(test)
 
     meta["metric"] = test["metric"]
     if "identifier" in test:


### PR DESCRIPTION
Summary:
An unnecessary change was messing up the Scuba logging.

Removed and it works again.

Reviewed By: axitkhurana

Differential Revision: D33035722

