### PR TITLE
Add "report" option to degrade

### DIFF
--- a/benchmarking/degrade/degrade_base.py
+++ b/benchmarking/degrade/degrade_base.py
@@ -19,11 +19,12 @@ class DegradeBase(object):
     For example:
         {
             "cpu": {
-                count: "4",
+                "count": "4",
             },
             "memory": {
-                limit: "2000000KB",
-            }
+                "limit": "2000000KB",
+            },
+            "report": true,
         }
 
     This class also acts as a default no-op implementation in the case that no implementation is registered for a given platform.


### PR DESCRIPTION
Summary:
Add "report" option to degrade.

Can be used with or without a degrade.

Report also "works" on unrooted devices, since it is only reading,

Results may not be 100% "complete" on all devices, depending on what each device supports.

For example, not all devices support (the same set of) Governors.

Reviewed By: axitkhurana

Differential Revision: D33152644

