### PR TITLE
Fix logging in platform utils for Android and iOS

### DIFF
--- a/benchmarking/platforms/android/adb.py
+++ b/benchmarking/platforms/android/adb.py
@@ -43,7 +43,7 @@ class ADB(PlatformUtilBase):
             return True
         except Exception:
             getLogger().critical(
-                f"Rebooting failure for device {self.device_kind} {self.device_hash}.",
+                f"Rebooting failure for device {self.device}.",
                 exc_info=True,
             )
             return False

--- a/benchmarking/platforms/ios/idb.py
+++ b/benchmarking/platforms/ios/idb.py
@@ -70,7 +70,7 @@ class IDB(PlatformUtilBase):
             return True
         except Exception:
             getLogger().critical(
-                f"Rebooting failure for device {self.device_kind} {self.device_hash}.",
+                f"Rebooting failure for device {self.device}.",
                 exc_info=True,
             )
             return False
@@ -91,7 +91,7 @@ class IDB(PlatformUtilBase):
             return level
         except Exception:
             getLogger().critical(
-                f"Could not read battery level for device {self.device_kind} {self.device_hash}.",
+                f"Could not read battery level for device {self.device}.",
                 exc_info=True,
             )
             return -1


### PR DESCRIPTION
Summary: Platform util class only has a device attribute (the device's hash).  Updates logging statements in the platform util files to use this value.

Reviewed By: axitkhurana

Differential Revision: D34154050

