### PR TITLE
Encapsulate adb getprop / setprop

### DIFF
--- a/benchmarking/platforms/android/adb.py
+++ b/benchmarking/platforms/android/adb.py
@@ -111,6 +111,14 @@ class ADB(PlatformUtilBase):
         su_cmd.extend(cmd)
         return self.shell(su_cmd, **kwargs)
 
+    def getprop(self, property: str, **kwargs):
+        if "default" not in kwargs:
+            kwargs["default"] = [""]
+        return self.shell(["getprop", property], **kwargs)[0].strip()
+
+    def setprop(self, property, value, **kwargs):
+        self.adb.shell(["setprop", property, value], **kwargs)
+
     def isRootedDevice(self, silent=True) -> bool:
         try:
             ret = self.shell(

--- a/benchmarking/platforms/android/android_platform.py
+++ b/benchmarking/platforms/android/android_platform.py
@@ -33,22 +33,16 @@ class AndroidPlatform(PlatformBase):
             args.device_name_mapping,
         )
         self.args = args
-        self.rel_version = adb.shell(
-            ["getprop", "ro.build.version.release"], default=""
-        )[0].strip()
-        self.build_version = adb.shell(["getprop", "ro.build.version.sdk"], default="")[
-            0
-        ].strip()
+        self.rel_version = adb.getprop("ro.build.version.release")
+        self.build_version = adb.getprop("ro.build.version.sdk")
         platform = (
-            adb.shell(["getprop", "ro.product.model"], default="")[0].strip()
+            adb.getprop("ro.product.model")
             + "-"
             + self.rel_version
             + "-"
             + self.build_version
         )
-        self.platform_abi = adb.shell(["getprop ro.product.cpu.abi"], default="")[
-            0
-        ].strip()
+        self.platform_abi = adb.getprop("ro.product.cpu.abi")
         self.os_version = "{}-{}".format(self.rel_version, self.build_version)
         self.type = "android"
         self.setPlatform(platform)


### PR DESCRIPTION
Summary: Encaplsulate adb getprop / setprop to make it easier to use and avoid pricking the wrong default type (needs to be an array in this case)

Reviewed By: axitkhurana

Differential Revision: D34391520

