### PR TITLE
Add timeout to logcat -G call to prevent deployment hanging on bad device.

### DIFF
--- a/benchmarking/platforms/android/adb.py
+++ b/benchmarking/platforms/android/adb.py
@@ -111,6 +111,14 @@ class ADB(PlatformUtilBase):
         su_cmd.extend(cmd)
         return self.shell(su_cmd, **kwargs)
 
+    def getprop(self, property: str, **kwargs):
+        if "default" not in kwargs:
+            kwargs["default"] = [""]
+        return self.shell(["getprop", property], **kwargs)[0].strip()
+
+    def setprop(self, property, value, **kwargs):
+        self.adb.shell(["setprop", property, value], **kwargs)
+
     def isRootedDevice(self, silent=True) -> bool:
         try:
             ret = self.shell(

--- a/benchmarking/platforms/android/android_platform.py
+++ b/benchmarking/platforms/android/android_platform.py
@@ -71,7 +71,7 @@ class AndroidPlatform(PlatformBase):
             # We know this command may fail. Avoid propogating this
             # failure to the upstream
             success = getRunStatus()
-            ret = self.util.logcat("-G", str(size) + "K")
+            ret = self.util.run(["logcat", "-G", str(size) + "K"], timeout=2, retry=1)
             setRunStatus(success, overwrite=True)
             if len(ret) > 0 and ret[0].find("failed to") >= 0:
                 repeat = True

--- a/benchmarking/platforms/android/android_platform.py
+++ b/benchmarking/platforms/android/android_platform.py
@@ -33,22 +33,16 @@ class AndroidPlatform(PlatformBase):
             args.device_name_mapping,
         )
         self.args = args
-        self.rel_version = adb.shell(
-            ["getprop", "ro.build.version.release"], default=""
-        )[0].strip()
-        self.build_version = adb.shell(["getprop", "ro.build.version.sdk"], default="")[
-            0
-        ].strip()
+        self.rel_version = adb.getprop("ro.build.version.release")
+        self.build_version = adb.getprop("ro.build.version.sdk")
         platform = (
-            adb.shell(["getprop", "ro.product.model"], default="")[0].strip()
+            adb.getprop("ro.product.model")
             + "-"
             + self.rel_version
             + "-"
             + self.build_version
         )
-        self.platform_abi = adb.shell(["getprop ro.product.cpu.abi"], default="")[
-            0
-        ].strip()
+        self.platform_abi = adb.getprop("ro.product.cpu.abi")
         self.os_version = "{}-{}".format(self.rel_version, self.build_version)
         self.type = "android"
         self.setPlatform(platform)


### PR DESCRIPTION
Summary: Add timeout to logcat -G call to prevent deployment hanging on bad device.

Reviewed By: axitkhurana

Differential Revision: D34527424

