### PR TITLE
Add file uploader for manifold

### DIFF
--- a/benchmarking/bridge/file_storage/upload_files/file_uploader_base.py
+++ b/benchmarking/bridge/file_storage/upload_files/file_uploader_base.py
@@ -1,0 +1,20 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+upload_handles = {}
+
+
+class FileUploaderBase(object):
+    def __init__(self):
+        pass
+
+    def upload_file(self, location, context, **kwargs):
+        pass
+
+
+def registerFileUploader(name, obj):
+    global upload_handles
+    upload_handles[name] = obj
+
+
+def getUploadHandles():
+    return upload_handles

--- a/benchmarking/bridge/file_storage/upload_files/upload_file.py
+++ b/benchmarking/bridge/file_storage/upload_files/upload_file.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from bridge.file_storage.upload_files.file_uploader_base import getUploadHandles
+
+
+class UploadFile(object):
+    def __init__(self):
+        self.upload_handles = getUploadHandles()
+        self.uploaders = {}
+
+    def upload_file(self, file, context: str, **kwargs):
+        if context not in self.upload_handles:
+            raise RuntimeError(f"No configuration found for {context}")
+        uploader = self.uploaders.get(context, self.upload_handles[context]())
+        return uploader.upload_file(file, context=context, **kwargs)


### PR DESCRIPTION
Summary:
Adds file_storage/upload_files package to bridge.
file_uploader_base:
base class for file uploaders, implemented with bridge classes e.g. manifold. context passed to uploader is used to load config for file upload.
upload_file:
register file_uploaders, get file_uploader by context
manifold_file_uploader:
manifold implementation of file_uploader_base, registered with "default" context.

Differential Revision: D34569309

