### PR TITLE
Manifold File Storage Fixes and Updates

### DIFF
--- a/benchmarking/bridge/file_storage/upload_files/upload_file.py
+++ b/benchmarking/bridge/file_storage/upload_files/upload_file.py
@@ -13,10 +13,14 @@ from bridge.file_storage.upload_files.file_uploader_base import getUploadHandles
 class UploadFile:
     def __init__(self):
         self.upload_handles = getUploadHandles()
-        self.uploaders = {}
 
     def upload_file(self, file, context: str, **kwargs):
         if context not in self.upload_handles:
             raise RuntimeError(f"No configuration found for {context}")
-        uploader = self.uploaders.get(context, self.upload_handles[context]())
+        uploader = self.upload_handles[context]()
         return uploader.upload_file(file, context=context, **kwargs)
+
+    def get_uploader(self, context, **kwargs):
+        if context not in self.upload_handles:
+            raise RuntimeError(f"No configuration found for {context}")
+        return self.upload_handles[context](context=context)


### PR DESCRIPTION
Summary:
manifold.py:
adds _gen_subdir to set self.subdir to a unique value for use if a blob is not provided for uploads.
upload()
now uses self.subdir if blob is not specified.
fix return value tail value which should only be {blob}

manifold_file_uploader.py:
add context manager functions to allow use of one instance to upload multiple files to same manifold path.

upload_file.py:
add get_uploader which will return an instance of the uploader class, and can be used in a context manager statement.

manifold_tests.py:
add context manager test.

Differential Revision: D34697456

