### PR TITLE
Only update output files meta if dict is not empty

### DIFF
--- a/benchmarking/frameworks/framework_base.py
+++ b/benchmarking/frameworks/framework_base.py
@@ -400,18 +400,20 @@ class FrameworkBase(object):
                 one_output = convert.convert(results)
                 deepMerge(output, one_output)
             if to_upload:
-                output["meta"]["output_files"] = {}
                 output_file_uploader = FileUploader("output_files").get_uploader()
+                output_file_meta = {}
                 for filename, file in to_upload.items():
                     try:
                         getLogger().info(f"Uploading {filename} ({file}) to manifold")
                         url = output_file_uploader.upload_file(file)
-                        output["meta"]["output_files"].update({filename: url})
+                        output_file_meta.update({filename: url})
                         getLogger().info(f"{file} uploaded to {url}")
                     except Exception:
                         getLogger().exception(
                             f"Could not upload output file {file}. Skipping."
                         )
+                if output_file_meta:
+                    output["meta"].update({"output_files": output_file_meta})
 
         return output, output_files
 


### PR DESCRIPTION
Summary:
Empty output_files dict can be passed into result->meta if uploading failed.
See https://www.internalfb.com/intern/aibench/details/214261733965211
Updates a local dict with valid entries first, and if not empty, updates result["meta"] with the output_files dict.

Differential Revision: D35069994

