### PR TITLE
Increase default shared memory buffer size based on production testing

### DIFF
--- a/benchmarking/profilers/perfetto/perfetto.py
+++ b/benchmarking/profilers/perfetto/perfetto.py
@@ -53,7 +53,9 @@ class Perfetto(ProfilerBase):
     DEFAULT_TIMEOUT = 5
     BUFFER_SIZE_KB_DEFAULT = 256 * 1024  # 256 megabytes
     BUFFER_SIZE2_KB_DEFAULT = 2 * 1024  # 2 megabytes
-    SHMEM_SIZE_BYTES_DEFAULT = 8388608
+    SHMEM_SIZE_BYTES_DEFAULT = (
+        8192 * 4096
+    )  # Shared memory buffer must be a large multiple of 4096
     SAMPLING_INTERVAL_BYTES_DEFAULT = 4096
     BATTERY_POLL_MS_DEFAULT = 1000
     MAX_FILE_SIZE_BYTES_DEFAULT = 100000000

--- a/benchmarking/profilers/utilities.py
+++ b/benchmarking/profilers/utilities.py
@@ -18,9 +18,14 @@ from utils.custom_logger import getLogger
 
 def generate_perf_filename(model_name="benchmark", hash=None):
     """Given the provided model name and optional hash, generate a unique base filename."""
-    if hash is None:
-        hash = uuid4()
-    return f"{model_name}_perf_{hash}"
+    unique_name = os.getenv("JOB_IDENTIFIER", None)
+    if unique_name is None:
+        unique_name = uuid4()
+    elif hash is None:
+        hash = os.getenv("JOB_ID", None)
+    if hash is not None:
+        unique_name += "_{hash}"
+    return f"{model_name}_perf_{unique_name}"
 
 
 def upload_profiling_reports(files: Mapping[str, str]) -> Dict:


### PR DESCRIPTION
Summary:
Increase default shared memory buffer size to 33554432 based on production testing on 5 devices.

Best results usually come from default sampling interval of 4096 bytes.

Reviewed By: MarkAndersonIX

Differential Revision: D35420550

