### PR TITLE
Ensure profiling results filename is always unique

### DIFF
--- a/benchmarking/profilers/utilities.py
+++ b/benchmarking/profilers/utilities.py
@@ -18,9 +18,14 @@ from utils.custom_logger import getLogger
 
 def generate_perf_filename(model_name="benchmark", hash=None):
     """Given the provided model name and optional hash, generate a unique base filename."""
-    if hash is None:
-        hash = uuid4()
-    return f"{model_name}_perf_{hash}"
+    unique_name = os.getenv("JOB_IDENTIFIER", None)
+    if unique_name is None:
+        unique_name = uuid4()
+    elif hash is None:
+        hash = os.getenv("JOB_ID", None)
+    if hash is not None:
+        unique_name += f"_{hash}"
+    return f"{model_name}_perf_{unique_name}"
 
 
 def upload_profiling_reports(files: Mapping[str, str]) -> Dict:


### PR DESCRIPTION
Summary:
Ensure profiling results filename is always unique.

It turns out we must not depend on the fact that we upload results to a unique folder.

This turns out to be useless if not redundant because once a result is download to (say) the users downloads folder, it will overwrite the local results of a previous run on the same device.

The device name is still very useful to tell which result you are looking for, but it is not enough.

Made the guid unconditional.

Reviewed By: MarkAndersonIX

Differential Revision: D35365811

