### PR TITLE
AIBench: runBinaryBenchmark(): Don't give critical logging error for known user errors.

### DIFF
--- a/benchmarking/run_lab.py
+++ b/benchmarking/run_lab.py
@@ -24,7 +24,6 @@ import shutil
 import signal
 import stat
 import tempfile
-import threading
 import time
 from concurrent.futures import ProcessPoolExecutor as Pool
 from io import StringIO

--- a/benchmarking/utils/utilities.py
+++ b/benchmarking/utils/utilities.py
@@ -39,14 +39,26 @@ KILLED_FLAG = 1 << 9
 EXTERNAL_STATUS_MASK = 0xFF
 
 
-class DownloadException(Exception):
+class BenchmarkException(Exception):
+    """Base class for all benchmark exceptions."""
+
+    pass
+
+
+class DownloadException(BenchmarkException):
     """Raised where exception occurs when downloading benchmark files."""
 
     pass
 
 
-class BenchmarkArgParseException(Exception):
+class BenchmarkArgParseException(BenchmarkException):
     """Raised where benchmark arguments could not be parsed or are invalid."""
+
+    pass
+
+
+class BenchmarkUnsupportedDeviceException(BenchmarkException):
+    """Raised where benchmark arguments specify an invalid device."""
 
     pass
 


### PR DESCRIPTION
Summary: Perfetto should not give a critical error for know errors. Leave any critical logging to the place that first sees the exception.

Reviewed By: MarkAndersonIX

Differential Revision: D35303625

