### PR TITLE
Add supress_dc_critical flag to supress dc task generation by hash.

### DIFF
--- a/benchmarking/platforms/device_manager.py
+++ b/benchmarking/platforms/device_manager.py
@@ -90,6 +90,14 @@ class DeviceManager(object):
             self.usb_controller = USBController(self.args.usb_hub_device_mapping)
         else:
             self.usb_controller = None
+        # specify device hashes to suppress critical logging for when d/c occurs.
+        self.suppress_dc_critical_mapping = {}
+        if self.args.suppress_dc_critical_mapping:
+            try:
+                with open(self.args.suppress_dc_critical_mapping) as f:
+                    self.suppress_dc_critical_mapping = set(json.load(f)["hashes"])
+            except Exception:
+                getLogger.exception("suppress_dc_critical_mapping was not loaded.")
 
     def getLabDevices(self):
         """Return a reference to the lab's device meta data."""
@@ -186,9 +194,11 @@ class DeviceManager(object):
                             f"Device {dc_device} has shown as disconnected {dc_count} time(s) and was able to be reconnected."
                         )
                     else:
-                        getLogger().critical(
-                            f"Device {dc_device} has shown as disconnected {dc_count} time(s) ({dc_count * self.device_monitor_interval}s) and is offline.",
-                        )
+                        device_offline_message = f"Device {dc_device} has shown as disconnected {dc_count} time(s) ({dc_count * self.device_monitor_interval}s) and is offline."
+                        if hash in self.suppress_dc_critical_mapping:
+                            getLogger().error(device_offline_message)
+                        else:
+                            getLogger().critical(device_offline_message)
                         self.online_devices.remove(dc_device)
                     self.device_dc_count.pop(hash)
 

--- a/benchmarking/run_lab.py
+++ b/benchmarking/run_lab.py
@@ -194,6 +194,11 @@ parser.add_argument(
     help="Specify the usb hub hash, port mapping to devices",
 )
 parser.add_argument(
+    "--suppress_dc_critical_mapping",
+    default=None,
+    help="Suppress critical logs for device dc by hash.",
+)
+parser.add_argument(
     "--file_storage", help="The storage engine for uploading and downloading files"
 )
 parser.add_argument("--benchmark_db_entry", help="The entry point of server's database")


### PR DESCRIPTION
Summary: For devices which are known to disconnect frequently.  Adds flag to run_lab to specify a json file in the form {"hashes": ["hash_01", ..]} which will tell DeviceMonitor class to only log dc as an error in the lab, and supress task generation for the d/c.

Differential Revision: D36085728

