### PR TITLE
FBPKG cleanup when new version is published T114512084

### DIFF
--- a/benchmarking/download_benchmarks/django_file_downloader.py
+++ b/benchmarking/download_benchmarks/django_file_downloader.py
@@ -14,6 +14,9 @@ class DjangoFileDownloader(FileDownloaderBase):
         self.root_model_dir = kwargs["args"].root_model_dir
 
     def download_file(self, location, path):
+        # Assume the file is the same
+        if os.path.exists(location):
+            return
         getLogger().info("Downloading from {} to {}".format(location, path))
         basedir = os.path.dirname(path)
         if not os.path.exists(basedir):
@@ -22,6 +25,7 @@ class DjangoFileDownloader(FileDownloaderBase):
         r = requests.get(location)
         if r.status_code == 200:
             with open(path, "wb") as f:
+                f.truncate(0)
                 f.write(r.content)
 
 

--- a/benchmarking/download_benchmarks/download_benchmarks.py
+++ b/benchmarking/download_benchmarks/download_benchmarks.py
@@ -123,9 +123,7 @@ class DownloadBenchmarks(object):
                         + " is cached, skip downloading"
                     )
                     return path
-            else:
-                # assume the file is the same
-                return path
+            # If file exists, but we don't have an md5, allow each downloader to handle this.
         downloader_controller = DownloadFile(
             dirs=dirs, logger=self.logger, args=self.args
         )


### PR DESCRIPTION
Summary:
Edits to fbpkg_file_downloader.py that removes any existing binary at the path specified. Added the --verify flag for fbpkgx to avoid downloading the package if it already exists. Added tests to test_downloads.py using fbpkg.fetch --verify to check version.

Edits as per prior comments including:
 - Remove shutil.rmtree(...) call to prevent cache from being deleted
 - Create dummy fbpkg instead of `fbpkg.fetch`ing an old version

Reviewed By: axitkhurana

Differential Revision: D35514597

