### PR TITLE
Remove hardcoded versions from device_name_mapping.py and resolve device name in platform classes.

### DIFF
--- a/benchmarking/platforms/android/android_platform.py
+++ b/benchmarking/platforms/android/android_platform.py
@@ -39,20 +39,22 @@ class AndroidPlatform(PlatformBase):
             args.device_name_mapping,
         )
         self.args = args
+        self.setPlatformHash(adb.device)
         self.rel_version = adb.getprop("ro.build.version.release")
         self.build_version = adb.getprop("ro.build.version.sdk")
-        platform = (
-            adb.getprop("ro.product.model")
-            + "-"
-            + self.rel_version
-            + "-"
-            + self.build_version
-        )
+        if self.platform:
+            self.platform_model = (
+                re.findall("(.*)-[0-9]*-[0-9]*", self.platform) or [self.platform]
+            )[0]
+        else:
+            self.platform_model = adb.getprop("ro.product.model").replace(" ", "-")
+            self.platform = (
+                self.platform_model + "-" + self.rel_version + "-" + self.build_version
+            )
         self.platform_abi = adb.getprop("ro.product.cpu.abi")
         self.os_version = "{}-{}".format(self.rel_version, self.build_version)
         self.type = "android"
-        self.setPlatform(platform)
-        self.setPlatformHash(adb.device)
+        self.setPlatform(self.platform)
         self.device_label = self.getMangledName()
         self.usb_controller = usb_controller
         self._setLogCatSize()
@@ -63,8 +65,6 @@ class AndroidPlatform(PlatformBase):
             self.util.setFrequency(self.args.set_freq)
 
     def getKind(self):
-        if self.platform_model and self.platform_os_version:
-            return "{}-{}".format(self.platform_model, self.platform_os_version)
         return self.platform
 
     def getOS(self):

--- a/benchmarking/platforms/platform_base.py
+++ b/benchmarking/platforms/platform_base.py
@@ -107,8 +107,8 @@ class PlatformBase(object):
 
     @abc.abstractmethod
     def getName(self):
-        if self.device_name_mapping and self.getKind() in self.device_name_mapping:
-            return self.device_name_mapping[self.getKind()]
+        if self.device_name_mapping and self.platform_model in self.device_name_mapping:
+            return self.device_name_mapping[self.platform_model]
         else:
             return "null"
 


### PR DESCRIPTION
Summary: Update platform logic to get names by the platform model without any versions postfixed.  This will resolve issues with devices losing their nametags when upgrades occur.

Reviewed By: axitkhurana

Differential Revision: D36747276

