### PR TITLE
Get memory profiling working again

### DIFF
--- a/benchmarking/profilers/perfetto/perfetto_config.py
+++ b/benchmarking/profilers/perfetto/perfetto_config.py
@@ -21,6 +21,7 @@ buffers: {{
 {linux_ftrace_config}\
 {android_log_config}\
 {track_event_config}\
+duration_ms: 3600000
 write_into_file: true
 file_write_period_ms: 2500
 max_file_size_bytes: {max_file_size_bytes}
@@ -52,6 +53,10 @@ data_sources: {{
         target_buffer: 0
         heapprofd_config {{
             sampling_interval_bytes: {sampling_interval_bytes}
+            continuous_dump_config {{
+                dump_phase_ms: {dump_phase_ms}
+                dump_interval_ms: {dump_interval_ms}
+            }}
             process_cmdline: "{app_name}"
             shmem_size_bytes: {shmem_size_bytes}
             block_client: true


### PR DESCRIPTION
Summary:
Get memory profiling working again.

It is now working again for rooted / meta devices and working better than ever.

Confirmed on Portal-NED-11-30 and MilanMini so far.

Still not working on unrooted, non-meta devices like Pixel-6-12-31 or Picel-6-Pro-12-31. I will work on that incrementally, but priority is to unblock our key customers.

Reviewed By: axitkhurana

Differential Revision: D36886272

