### PR TITLE
Android platform product model regex catches .'s

### DIFF
--- a/benchmarking/platforms/android/android_platform.py
+++ b/benchmarking/platforms/android/android_platform.py
@@ -44,7 +44,7 @@ class AndroidPlatform(PlatformBase):
         self.build_version = adb.getprop("ro.build.version.sdk")
         if self.platform:
             self.platform_model = (
-                re.findall("(.*)-[0-9]*-[0-9]*", self.platform) or [self.platform]
+                re.findall(r"(.*)-[0-9.]*-[0-9.]*", self.platform) or [self.platform]
             )[0]
         else:
             self.platform_model = adb.getprop("ro.product.model").replace(" ", "-")


### PR DESCRIPTION
Summary: Fix product model resolution regex to support devices with OS version with precisions such as 8.0.1

Differential Revision: D36961682

