### PR TITLE
Add Counter and ODSCounter classes to AIBench

### DIFF
--- a/benchmarking/metrics/counters.py
+++ b/benchmarking/metrics/counters.py
@@ -1,0 +1,34 @@
+##############################################################################
+# Copyright 2022-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+##############################################################################
+
+counter_handles = {}
+
+from typing import Dict, List
+
+
+class Counter:
+    def __init__(self, context: str = "default"):
+        self.counter_handles = get_counter_handles()
+        if context not in self.counter_handles:
+            raise RuntimeError(f"No configuration found for {context}")
+        self.counter = self.counter_handles[context]()
+
+    def update_counters(self, data: List[Dict]):
+        return self.counter.update_counters(data)
+
+    def get_counter(self):
+        return self.counter
+
+
+def register_counter_handle(name, obj):
+    global counter_handles
+    counter_handles[name] = obj
+
+
+def get_counter_handles():
+    return counter_handles

--- a/benchmarking/platforms/device_manager.py
+++ b/benchmarking/platforms/device_manager.py
@@ -15,7 +15,6 @@ import json
 import time
 from collections import defaultdict
 from threading import Thread
-from typing import Dict
 
 from bridge.db import DBDriver
 from get_connected_devices import GetConnectedDevices
@@ -68,7 +67,7 @@ class DeviceManager(object):
     Provides devices metadata to the lab instance. For mobile platforms, checks connectivity of devices and performs updates to lab devices and db.
     """
 
-    def __init__(self, args: Dict, db: DBDriver):
+    def __init__(self, args, db: DBDriver):
         self.args = args
         self.db: DBDriver = db
         self.lab_devices = {}
@@ -78,11 +77,9 @@ class DeviceManager(object):
         self._initializeDevices()
         self.running = True
         self.failed_device_checks = 0
-        # pyre-fixme[16]: `Dict` has no attribute `device_monitor_interval`.
         self.device_monitor_interval = self.args.device_monitor_interval
         self.device_monitor = Thread(target=self._runDeviceMonitor)
         self.device_monitor.start()
-        # pyre-fixme[16]: `Dict` has no attribute `usb_hub_device_mapping`.
         if self.args.usb_hub_device_mapping:
             from utils.usb_controller import USBController
 
@@ -91,14 +88,12 @@ class DeviceManager(object):
             self.usb_controller = None
         # specify device hashes to suppress critical logging for when d/c occurs.
         self.suppress_dc_critical_mapping = {}
-        # pyre-fixme[16]: `Dict` has no attribute `suppress_dc_critical_mapping`.
         if self.args.suppress_dc_critical_mapping:
             try:
                 with open(self.args.suppress_dc_critical_mapping) as f:
                     self.suppress_dc_critical_mapping = set(json.load(f)["hashes"])
             except Exception:
-                # pyre-fixme[16]: Callable `getLogger` has no attribute `exception`.
-                getLogger.exception("suppress_dc_critical_mapping was not loaded.")
+                getLogger().exception("suppress_dc_critical_mapping was not loaded.")
 
     def getLabDevices(self):
         """Return a reference to the lab's device meta data."""

--- a/benchmarking/platforms/device_manager.py
+++ b/benchmarking/platforms/device_manager.py
@@ -18,6 +18,7 @@ from threading import Thread
 
 from bridge.db import DBDriver
 from get_connected_devices import GetConnectedDevices
+from metrics.counters import Counter
 from platforms.android.adb import ADB
 from platforms.platforms import getDeviceList
 from reboot_device import reboot as reboot_device
@@ -77,6 +78,14 @@ class DeviceManager(object):
         self._initializeDevices()
         self.running = True
         self.failed_device_checks = 0
+        self.counter = None
+        if self.args.device_counters:
+            try:
+                self.counter = Counter().get_counter()
+            except Exception:
+                getLogger().exception(
+                    "Could not load device counter!  Counters will not be updated for this server!"
+                )
         self.device_monitor_interval = self.args.device_monitor_interval
         self.device_monitor = Thread(target=self._runDeviceMonitor)
         self.device_monitor.start()
@@ -100,6 +109,7 @@ class DeviceManager(object):
         return self.lab_devices
 
     def _runDeviceMonitor(self):
+        self._initCounters()
         while self.running:
             # if the lab is hosting mobile devices, thread will monitor connectivity of devices.
             if self.args.platform.startswith(
@@ -107,6 +117,7 @@ class DeviceManager(object):
             ) or self.args.platform.startswith("ios"):
                 self._checkDevices()
             self._updateHeartbeats()
+            self._updateCounters()
             time.sleep(self.device_monitor_interval)
 
     def _checkDevices(self):
@@ -232,6 +243,34 @@ class DeviceManager(object):
                     hashes.append(hash)
         hashes = ",".join(hashes)
         self.db.updateHeartbeats(claimer_id, hashes)
+
+    def _initCounters(self):
+        """Update counters data for devices."""
+        if self.args.device_counters:
+            data = []
+            for k in self.lab_devices:
+                for hash in self.lab_devices[k]:
+                    data.append(
+                        {
+                            "key": f"{hash}.connected",
+                            "value": 0.0,
+                        }
+                    )
+            self.counter.update_counters(data)
+
+    def _updateCounters(self):
+        """Update counters data for devices."""
+        if self.args.device_counters:
+            data = []
+            for k in self.lab_devices:
+                for hash in self.lab_devices[k]:
+                    data.append(
+                        {
+                            "key": f"{hash}.connected",
+                            "value": 1.0 if self.lab_devices[k][hash]["live"] else 0.0,
+                        }
+                    )
+            self.counter.update_counters(data)
 
     def _getDevices(self, devices=None):
         """Get list of device meta data for available devices."""

--- a/benchmarking/run_lab.py
+++ b/benchmarking/run_lab.py
@@ -160,6 +160,11 @@ parser.add_argument(
     ),
 )
 parser.add_argument(
+    "--device_counters",
+    action="store_true",
+    help="Post device counter information from device monitor.",
+)
+parser.add_argument(
     "--shared_libs",
     help="Pass the shared libs that the framework depends on, "
     "in a comma separated list.",


### PR DESCRIPTION
Summary: Adds Counter class to OSS, and ODSCounter class to internal.  Counter can be used to bump counters with data given a key and a value as a float.  DeviceMonitor thread will now bump counters in ODS at entity "aibench_devices" for device connctivity based on the "live" value in the device dict.  Key is set to <hash>.connected.

Differential Revision: D37271565

