### PR TITLE
Check battery status before returning device to pool

### DIFF
--- a/benchmarking/platforms/android/adb.py
+++ b/benchmarking/platforms/android/adb.py
@@ -132,6 +132,24 @@ class ADB(PlatformUtilBase):
     def setprop(self, property, value, **kwargs):
         self.shell(["setprop", property, value], **kwargs)
 
+    def getBatteryProp(self, property: str, silent=True) -> str:
+        """
+        For rooted devices, you should already establish "user is root" before calling
+        """
+        if self.user_is_root():
+            path = "/sys/class/power_supply/battery/" + property
+            # Make sure path exists before trying to get it
+            if not (
+                self.shell(["[", "-f", '"' + path + '"', "]"], retry=1, silent=silent)
+            ):
+                return self.shell(
+                    ["cat", path],
+                    retry=1,
+                    silent=silent,
+                )[0]
+
+        return ""
+
     def isRootedDevice(self, silent=True) -> bool:
         try:
             ret = self.shell(

--- a/benchmarking/platforms/battery_state.py
+++ b/benchmarking/platforms/battery_state.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+##############################################################################
+# Copyright 2022-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+##############################################################################
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from typing import Any, Dict
+
+from platforms.android.adb import ADB
+from platforms.ios.idb import IDB
+
+
+def getBatteryState(device, platform: str, android_dir: str) -> Dict[str, Any]:
+    state: Dict[str, Any] = {"supported": False}
+    if platform.startswith("ios"):
+        util = IDB(device)
+        return state  # NYI
+    elif platform.startswith("android"):
+        util = ADB(device, android_dir)
+        if util.isRootedDevice():
+            if not util.user_is_root():
+                util.root(silent=True)
+            state["supported"] = util.getBatteryProp("present") == "1"
+
+        if state["supported"]:
+            state["disconnected"] = util.getBatteryProp("input_suspend") == "1"
+            state["status"] = util.getBatteryProp("status")
+            state["charge_level"] = int(util.getBatteryProp("capacity"))
+            state["temperature"] = int(util.getBatteryProp("temp"))
+
+    else:
+        raise AssertionError("Platform {} not recognized".format(platform))
+
+    return state

--- a/benchmarking/profilers/perfetto/perfetto.py
+++ b/benchmarking/profilers/perfetto/perfetto.py
@@ -131,7 +131,6 @@ class Perfetto(ProfilerBase):
 
         # This is a generic path to disconnect battery charing on many Android devices.
         # Going forward, it may be necessary to override this default mechanism on some devices.
-        self.battery_present_path = "/sys/class/power_supply/battery/present"
         self.battery_disconnected_path = "/sys/class/power_supply/battery/input_suspend"
         self.battery_state: BatteryState = BatteryState.connected
 
@@ -230,8 +229,7 @@ class Perfetto(ProfilerBase):
             self.valid = False  # prevent additional calls
 
     def _hasBattery(self):
-        cmd_has_battery = ["cat", self.battery_present_path]
-        return self.adb.shell(cmd_has_battery, retry=1, silent=True) == ["1"]
+        return self.adb.getBatteryProp("present") == "1"
 
     def _setBatteryState(self, state: BatteryState):
         cmd_exists = ["ls", self.battery_disconnected_path]


### PR DESCRIPTION
Summary:
Check battery status before returning device to pool.

Initially, charge threshold will be set to 30%, subject to future refinement or customization.

Reviewed By: MarkAndersonIX

Differential Revision: D37426433

