### PR TITLE
Allow passing random extra args to simpleperf

### DIFF
--- a/benchmarking/platforms/android/android_platform.py
+++ b/benchmarking/platforms/android/android_platform.py
@@ -310,6 +310,9 @@ class AndroidPlatform(PlatformBase):
             platform=self,
             model_name=platform_args.get("model_name", None),
             cmd=cmd,
+            extra_args=platform_args["profiling_args"]
+            .get("options", {})
+            .get("extra_args", ""),
         )
         if simpleperf:
             f = simpleperf.start()


### PR DESCRIPTION
Summary:
* Works only with Simpleperf (cpu) for now, silently ignored by other profilers
* The `extra_args` field defaults to an empty string, and goes to the simpleperf cmdline
 like this, `simpleperf record -g -o <filemame> <extra_args> <app cmdline>`
* No actual testing is done on the incoming string, it is passed to simple perf as is for now

Reviewed By: axitkhurana

Differential Revision: D37830096

