### PR TITLE
Remove assertion error from platform check in getBatteryState

### DIFF
--- a/benchmarking/platforms/battery_state.py
+++ b/benchmarking/platforms/battery_state.py
@@ -34,7 +34,4 @@ def getBatteryState(device, platform: str, android_dir: str) -> Dict[str, Any]:
             state["charge_level"] = int(util.getBatteryProp("capacity"))
             state["temperature"] = int(util.getBatteryProp("temp"))
 
-    else:
-        raise AssertionError("Platform {} not recognized".format(platform))
-
     return state


### PR DESCRIPTION
Summary: Removes unused assertion which can break fb_server instances.

Reviewed By: vmpuri

Differential Revision: D37897857

