### PR TITLE
Handle 404 and 410 download errors with non-critical exception

### DIFF
--- a/benchmarking/run_lab.py
+++ b/benchmarking/run_lab.py
@@ -50,6 +50,7 @@ from utils.log_utils import (
 from utils.utilities import (
     BenchmarkArgParseException,
     DownloadException,
+    DownloadNotFoundException,
     getFilename,
     getMachineId,
     HARNESS_ERROR_FLAG as HARNESS_ERROR,
@@ -309,7 +310,11 @@ class runAsync(object):
                 f"Running BenchmarkDriver for benchmark {self.job['identifier']} id ({self.job['id']})"
             )
             status = app.run()
-
+        except DownloadNotFoundException:
+            getLogger().exception(
+                f"An file could not be found when downloading files for benchmark {self.job['identifier']} id ({self.job['id']})"
+            )
+            status = USER_ERROR
         except DownloadException:
             getLogger().critical(
                 f"An error occurred while downloading files for benchmark {self.job['identifier']} id ({self.job['id']}",
@@ -502,6 +507,10 @@ class runAsync(object):
                         getLogger().info("Downloading control binary")
                         control_locations = self._downloadBinaries(control_info)
                         self.job["programs_location"].extend(control_locations)
+        except FileNotFoundError:
+            raise DownloadNotFoundException(
+                f"Failed to download files for benchmark {self.job['identifier']} id {self.job['id']}"
+            )
         except Exception:
             raise DownloadException(
                 f"Failed to download files for benchmark {self.job['identifier']} id {self.job['id']}"

--- a/benchmarking/utils/utilities.py
+++ b/benchmarking/utils/utilities.py
@@ -51,6 +51,10 @@ class DownloadException(BenchmarkException):
 
     pass
 
+class DownloadNotFoundException(BenchmarkException):
+    """Raised where exception occurs when downloading benchmark files."""
+
+    pass
 
 class BenchmarkArgParseException(BenchmarkException):
     """Raised where benchmark arguments could not be parsed or are invalid."""


### PR DESCRIPTION
Summary:
See https://www.internalfb.com/intern/aibench/details/685929341406384
Benchmarks which reference expired or otherwise non-existant files can be very verbose and generate a critical log and task to oncall.  Adds DownloadNotFoundException to handle 404 and 410 errors without critical logging.

Differential Revision: D38029506

