### PR TITLE
Fix paired arg parsing where = assignment used

### DIFF
--- a/benchmarking/platforms/platform_base.py
+++ b/benchmarking/platforms/platform_base.py
@@ -214,13 +214,19 @@ class PlatformBase(object):
             entry = cmd[i]
             if entry[:2] == "--":
                 key = entry[2:]
-                value = cmd[i + 1] if i < len(cmd) - 1 else "true"
-                if value[:2] == "--":
-                    value = "true"
+                if key.find("=") > -1:
+                    k, v = key.split("=")
+                    arguments[k] = v
                 else:
-                    i = i + 1
-                arguments[key] = value
+                    value = cmd[i + 1] if i < len(cmd) - 1 else "true"
+                    if value[:2] == "--":
+                        value = "true"
+                    else:
+                        i = i + 1
+                    arguments[key] = value
             elif entry != "{program}":
-                getLogger().warning("Failed to get argument {}".format(entry[i]))
+                raise RuntimeError(
+                    f"Argument '{cmd[i]}' could not be parsed from the command '{' '.join(cmd)}'."
+                )
             i = i + 1
         return arguments

--- a/benchmarking/tests/platforms/test_platform_base.py
+++ b/benchmarking/tests/platforms/test_platform_base.py
@@ -1,0 +1,73 @@
+##############################################################################
+# Copyright 2022-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+##############################################################################
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+from unittest.mock import Mock
+
+from platforms.platform_base import PlatformBase
+
+
+class PlatformBaseTest(unittest.TestCase):
+    def setUp(self):
+        platform_util = Mock()
+        platform_util.device = "hash"
+        self.platform = PlatformBase(None, None, platform_util, None, None)
+
+    def test_get_paired_arguments(self):
+        err_cmd = [
+            "{program}",
+            "--model",
+            "/tmp/nlu_model_bundled.ptl",
+            "--use_bundled_input=0",
+            "--warmup",
+            "10",
+            "--iter",
+            "50",
+            "--report_pep",
+            "true",
+            "—use_caching_allocator",  # single -, invalid token
+            "true",
+        ]
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Argument '—use_caching_allocator' could not be parsed from the command",
+        ):
+            self.platform.getPairedArguments(err_cmd)
+
+        valid_cmd = [
+            "{program}",
+            "--model",
+            "/tmp/nlu_model_bundled.ptl",
+            "--use_bundled_input=0",
+            "--warmup",
+            "10",
+            "--iter",
+            "50",
+            "--report_pep",
+            "true",
+            "--use_caching_allocator",  # single -, invalid token
+            "true",
+        ]
+        res = self.platform.getPairedArguments(valid_cmd)
+        self.assertEqual(
+            res,
+            {
+                "iter": "50",
+                "model": "/tmp/nlu_model_bundled.ptl",
+                "report_pep": "true",
+                "use_bundled_input": "0",
+                "use_caching_allocator": "true",
+                "warmup": "10",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
A command such as "{program} --model {files.model} --use_bundled_input=0 --warmup {warmup} --iter {iter} --report_pep true —use_caching_allocator true" breaks in getPairedArguments.  There is a '—' in the use_caching_allocator flag which is invalid.

Original tasks benchmark:
https://www.internalfb.com/intern/aibench/details/25557972222383

working on android:
https://www.internalfb.com/intern/aibench/details/260947414999894
breaks on ios:
https://www.internalfb.com/intern/aibench/details/430115216537078
The run does not break on android since getPairedArguments is not called in the runBinaryBenchmark function.

Update error logging to index cmd, instead of entry (a string).
Add unit tests for getPairedArguments
Add support for = in token (split into key, value)

Differential Revision: D38027273

