### PR TITLE
Add simpleperf stat support

### DIFF
--- a/benchmarking/frameworks/framework_base.py
+++ b/benchmarking/frameworks/framework_base.py
@@ -412,7 +412,10 @@ class FrameworkBase(object):
                             f"Could not upload output file {file}. Skipping."
                         )
                 if output_file_meta:
-                    output["meta"].update({"output_files": output_file_meta})
+                    if "output_files" in output["meta"]:
+                        output["meta"]["output_files"].update(output_file_meta)
+                    else:
+                        output["meta"].update({"output_files": output_file_meta})
 
         return output, output_files
 

--- a/benchmarking/platforms/android/android_platform.py
+++ b/benchmarking/platforms/android/android_platform.py
@@ -304,15 +304,16 @@ class AndroidPlatform(PlatformBase):
     def _runBenchmarkWithSimpleperf(
         self, cmd, log_to_screen_only: bool, **platform_args
     ):
+        stat = platform_args["profiling_args"].get("stat", None)
+        options = platform_args["profiling_args"].get("options", {})
         simpleperf = getProfilerByUsage(
             "android",
             None,
             platform=self,
-            model_name=platform_args.get("model_name", None),
             cmd=cmd,
-            extra_args=platform_args["profiling_args"]
-            .get("options", {})
-            .get("extra_args", ""),
+            stat=stat,
+            model_name=platform_args.get("model_name", None),
+            options=options,
         )
         if simpleperf:
             f = simpleperf.start()

--- a/benchmarking/profilers/utilities.py
+++ b/benchmarking/profilers/utilities.py
@@ -30,9 +30,9 @@ def generate_perf_filename(model_name="benchmark", hash=None):
 
 def upload_profiling_reports(files: Mapping[str, str]) -> Dict:
     """
-    Upload to aibench profiling reports manifold bucket.
+    Upload to aibench profiling reports.
     Accepts dict of key -> local file path, uploads using file basename
-    and returns meta dict of key -> manifold_url.
+    and returns meta dict of key -> url.
     """
     meta = {}
     profiling_reports_uploader = FileUploader("profiling_reports").get_uploader()
@@ -46,4 +46,23 @@ def upload_profiling_reports(files: Mapping[str, str]) -> Dict:
             getLogger().exception(
                 f"Warning: could not upload {key}: {file}. Skipping.\nException: {e}"
             )
+    return meta
+
+
+def upload_output_files(files: Mapping[str, str]) -> Dict:
+    """
+    Upload to aibench profiling reports.
+    Accepts dict of key -> local file path, uploads using file basename
+    and returns meta dict of key -> url.
+    """
+    meta = {}
+    profiling_reports_uploader = FileUploader("output_files").get_uploader()
+    for key, file in files.items():
+        if not os.path.isfile(file):
+            raise FileNotFoundError(f"File {file} does not exist.")
+        try:
+            url = profiling_reports_uploader.upload_file(file)
+            meta.update({key: url})
+        except Exception:
+            getLogger().exception(f"Warning: could not upload {key}: {file}. Skipping.")
     return meta


### PR DESCRIPTION
Summary:
Add simpleperf stat support

Proposed wiki entry (under simpleperf section):

Simpleperf Statistics Reporting (Stat):
A separate option for simpleperf is to use the "stat" command to generate various statistics or event-based information about a benchmark run. For example, it can report default statistics about the run or a huge variety of event-based statistics. For example, you can look at cache misses from the run, or even group various event data together.
Supported events may vary from one device to another, but for a general idea of what is possible, see the stat section at https://android.googlesource.com/platform/prebuilts/simpleperf/+/782cdf2ea6e33f2414b53884742d59fe11f01ebe/README.md and / or run "simpleperf list" on your device for an exhaustive list of possible events.
For AIBenchAPI or when working from the benchmark_config file, you can simply add a new
"stat": "<event_args_string> to the existing profile argument.
<event_args_string> is a simple string exactly like you would pass to "simpleperf stat" on the command line, for example:
"-e instructions --group cache-misses,cache-references"
"" will list the default stat output, as you would expect.
The main drawback to this simple string approach is that it cannot be used for CLI / buck run benchmark invocations.
If you need a format that can also be used from the command line, we support the following richer format:
"stat": [<event_options_list1>, <event_options_list2>, ...]
where <event_options_list> are zero or more lists of event options of the equivalent formats:
["event", "cache-misses", "cache-references"] or
["e", "cache-misses", "cache-references"] or
["-e", "cache-misses", "cache-references]

Similarly:
["group", cache-misses:u", "cache-references:u"] or
["--group", cache-misses:u", "cache-references:u"]
An empty list also produces the default stat output.

The CLI syntax for this is:
--profile { "enabled": true, "profiler": "simpleperf", "stat": [<event-options>...]}
where <event-options> is zero or more lists of event arguments.
Here are some examples:
"stat": [["e", "cache-misses"], ["group", "cache-references", "cache-references:u"]]
"stat": []

As noted earlier, this rich format can also be passed to the profile argument of the AIBench API functions or added to.
the "profiler": section of the "tests" entry of your benchmark config:
..
  "tests": [
    {
      "command": "{program} --model {files.model}  --input_dims \"1,3,224,224\" --input_type float --warmup {warmup} --iter {iter} --input_memory_format \"channels_last\"",
      "identifier": "{ID}",
      "iter": 500,
      "profiler": {
        "enabled": true,
        "profiler": "simpleperf",
        "stat": [
          ["e", "cache-misses"],
          ["group", "cache-references", "cache-references:u"]
        ]
      },
      "warmup": 1
    }
  ]
}

Notes:
The "profiler": "simpleperf" portion may be optional since "simpleperf" is currently the default profiler, but it is a good idea to specify it since additional profilers will be added in the future.

Reviewed By: axitkhurana

Differential Revision: D37875523

