### PR TITLE
Update iOSPlatform to mask platform_model with mapping.

### DIFF
--- a/benchmarking/platforms/ios/ios_driver.py
+++ b/benchmarking/platforms/ios/ios_driver.py
@@ -88,7 +88,7 @@ class IOSDriver(object):
                 "abi": self.devices[device]["abi"],
             }
             platform = IOSPlatform(tempdir, idb, self.args, platform_meta)
-            platform.setPlatform(self.devices[device]["model"])
+            # platform.setPlatform(self.devices[device]["platform"])
             platforms.append(platform)
 
         return platforms

--- a/benchmarking/platforms/ios/ios_platform.py
+++ b/benchmarking/platforms/ios/ios_platform.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import json
 import os
+import re
 import shlex
 import time
 
@@ -31,10 +32,15 @@ class IOSPlatform(PlatformBase):
             args.hash_platform_mapping,
             args.device_name_mapping,
         )
-        self.platform_os_version = platform_meta.get("os_version")
-        self.platform_model = platform_meta.get("model")
-        self.platform_abi = platform_meta.get("abi")
         self.setPlatformHash(idb.device)
+        if self.platform:
+            self.platform_model = (
+                re.findall(r"(.*)-[0-9.]+", self.platform) or [self.platform]
+            )[0]
+        else:
+            self.platform_model = platform_meta.get("model")
+        self.platform_os_version = platform_meta.get("os_version")
+        self.platform_abi = platform_meta.get("abi")
         self.usb_controller = usb_controller
         self.type = "ios"
         self.app = None


### PR DESCRIPTION
Summary: Update platform_model resolution for iOS platform, enables device-name mapping on top of a hash-platform map (equivalent to android platforms)

Reviewed By: vmpuri

Differential Revision: D38529898

