### PR TITLE
iOS Fix Multi-device Runs due to FileNotFound Error

### DIFF
--- a/benchmarking/run_lab.py
+++ b/benchmarking/run_lab.py
@@ -458,7 +458,16 @@ class runAsync(object):
                 and not program_location.endswith(".ipa")
             ):
                 new_location = program_location + ".ipa"
-                os.rename(program_location, new_location)
+                # This is a fix to resolve FileNotFound errors
+                # caused by renaming the program to its .ipa filename.
+                # TODO: Improve benchmark file handling with either
+                # temp directories per device / id or using file locks.
+                if (
+                    not os.path.exists(new_location)
+                    or os.stat(program_location).st_mtime
+                    != os.stat(new_location).st_mtime
+                ):
+                    shutil.copyfile(program_location, new_location)
                 program_location = new_location
             os.chmod(program_location, stat.S_IXUSR | stat.S_IRUSR | stat.S_IWUSR)
             programs[bin_name]["location"] = program_location


### PR DESCRIPTION
Summary: Where several devices or benchmarks are running at the time time on the same ios program, moving the filename to include .ipa extension can cause FileNotFound errors.  Replaces rename with shutil.copyfile and does a check for modified time to see whether it should copy the file.  This is a temporary fix and better download logic should be implemented longterm.

Differential Revision: D38891186

