### PR TITLE
Add bridge file downloader

### DIFF
--- a/benchmarking/bridge/file_storage/download_files/file_downloader.py
+++ b/benchmarking/bridge/file_storage/download_files/file_downloader.py
@@ -1,0 +1,32 @@
+##############################################################################
+# Copyright 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+##############################################################################
+
+download_handles = {}
+
+
+class FileDownloader:
+    def __init__(self, context: str = "default"):
+        self.download_handles = getDownloadHandles()
+        if context not in self.download_handles:
+            raise RuntimeError(f"No configuration found for {context}")
+        self.downloader = self.download_handles[context]()
+
+    def downloadFile(self, file, blob=None):
+        return self.downloader.downloadFile(file, blob=blob)
+
+    def getDownloader(self):
+        return self.downloader
+
+
+def registerFileDownloader(name, obj):
+    global download_handles
+    download_handles[name] = obj
+
+
+def getDownloadHandles():
+    return download_handles


### PR DESCRIPTION
Summary:
Add bridge file downloader

Purpose is to add an OSS file_downloader.py to match the existing OSS file_uploader.py.

Implementation-specific version is not included in OSS.

Reviewed By: axitkhurana

Differential Revision: D39421795

