### PR TITLE
Sideloading of perfetto binary

### DIFF
--- a/benchmarking/bridge/file_storage/download_files/file_downloader.py
+++ b/benchmarking/bridge/file_storage/download_files/file_downloader.py
@@ -1,0 +1,32 @@
+##############################################################################
+# Copyright 2022-present, Meta, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+##############################################################################
+
+download_handles = {}
+
+
+class FileDownloader:
+    def __init__(self, context: str = "default"):
+        self.download_handles = getDownloadHandles()
+        if context not in self.download_handles:
+            raise RuntimeError(f"No configuration found for {context}")
+        self.downloader = self.download_handles[context]()
+
+    def downloadFile(self, file, blob=None):
+        return self.downloader.downloadFile(file, blob=blob)
+
+    def getDownloader(self):
+        return self.downloader
+
+
+def registerFileDownloader(name, obj):
+    global download_handles
+    download_handles[name] = obj
+
+
+def getDownloadHandles():
+    return download_handles

--- a/benchmarking/platforms/android/android_platform.py
+++ b/benchmarking/platforms/android/android_platform.py
@@ -266,7 +266,7 @@ class AndroidPlatform(PlatformBase):
                     elif profiler == "perfetto":
                         if not PerfettoAllSupported(profiling_types):
                             raise BenchmarkArgParseException(
-                                f"Only [{' ,'.join(perfetto_types_supported)}] are supported types for perfetto profiling."
+                                f"Only [{', '.join(perfetto_types_supported)}] are supported types for perfetto profiling."
                             )
                         # attempt Perfetto profiling, else fallback to standard run
                         return self._runBenchmarkWithPerfetto(

--- a/benchmarking/tests/test_profiling/test_perfetto_config.py
+++ b/benchmarking/tests/test_profiling/test_perfetto_config.py
@@ -84,7 +84,7 @@ data_sources: {
                 dump_interval_ms: 1000
             }
             process_cmdline: "program"
-            shmem_size_bytes: 33554432
+            shmem_size_bytes: 67108864
             block_client: true
         }
     }
@@ -120,7 +120,7 @@ data_sources: {
                 dump_interval_ms: 1000
             }
             process_cmdline: "program"
-            shmem_size_bytes: 33554432
+            shmem_size_bytes: 67108864
             block_client: true
         }
     }
@@ -303,7 +303,7 @@ data_sources: {
                 dump_interval_ms: 1000
             }
             process_cmdline: "program"
-            shmem_size_bytes: 33554432
+            shmem_size_bytes: 67108864
             block_client: true
         }
     }


### PR DESCRIPTION
Summary:
Sideloading of perfetto binary

(based on earlier diff D36329256 and leveraging a private build based on D39229401)

The motivation here is to build our own copy of the perfetto binary based on the latest OS 12 sources from  https://github.com/google/perfetto (OSS). This offers several advantages:

1. Better Perfetto support and fewer errors by using the Android OS 12 version of perfetto even on older systems running older versions of perfetto natively.
2. At least limited perfetto support on some devices not currently running at least Android OS 10 and therefore with no native perfetto binary.
3. Ability to run against a debug version of perfetto for better logging and debugging capabilities.
4. This also gives us our own built traceconv binary which we will probably want to use going forward to better format the output.

Limitations:
1. Doesn't really expand memory profiling capability (yet) to all devices. Further work is required to see if further coverage is possible.
2. Doesn't directly overcome any permissions problems related to working on unrooted devices, although in some cases it gets us closer to solving that.
3. Current build includes arm and arm64 flavors only. x86 and x86_64 flavors are also can be built out-of-the-box, but any other variations would take further build configuration work. However, this should cover most of our uncovered devices.

Not a panacea, but potentially a big step in the right direction.

Reviewed By: axitkhurana

Differential Revision: D39291671

