### PR TITLE
Restore memory profiling error for OS < 10 for now

### DIFF
--- a/benchmarking/profilers/perfetto/perfetto.py
+++ b/benchmarking/profilers/perfetto/perfetto.py
@@ -274,7 +274,7 @@ class Perfetto(ProfilerBase):
 
         if "memory" in self.types:
             # perfetto has stopped supporting Android 10 for memory profiling!
-            if self.android_version < 11 and not self.advanced_support:
+            if self.android_version < 10:  # TODO: < 11 and not self.advanced_support:
                 raise BenchmarkUnsupportedDeviceException(
                     f"Attempt to run perfetto memory profiling on {self.platform.type} {self.platform.rel_version} device {self.platform.device_label} ignored."
                 )


### PR DESCRIPTION
Summary:
Restore memory profiling error for OS < 10 for now.

The intent was to enable perfetto profiling for OS < 10 by adding sideloading and mostly the old check worked except it still doesn't work due to a permissions problem on certain rooted devices which I still need to fix separately.

Reviewed By: Junah-Park

Differential Revision: D39913049

