### PR TITLE
Monsoon close device may fail, retry 5 times if fails

### DIFF
--- a/benchmarking/utils/monsoon_power.py
+++ b/benchmarking/utils/monsoon_power.py
@@ -89,8 +89,20 @@ def collectPowerData(
 
     samples = engine.getSamples()
 
-    getLogger().info("Closing device")
-    Mon.closeDevice()
+    # device may not be available,
+    # try reconnect 5 times before fail
+    repeat = 0
+    while repeat < 5:
+        try:
+            getLogger().info("Closing device")
+            Mon.closeDevice()
+            break
+        except Exception:
+            repeat = repeat + 1
+            sleep(2)
+    if repeat >= 5:
+        getLogger().info("Failed to close device")
+        return {}
 
     power_data, url = _extract_samples(samples, has_usb)
 


### PR DESCRIPTION
Summary: The computer sometimes may not find the connected Monsoon power monitor. If this happens, a retry may solve the problem. Instead of fails the training, retry closing the device 5 times.

Reviewed By: vmpuri

Differential Revision: D45922795

