### PR TITLE
Set current time on AndroidPlatform instantiation.

### DIFF
--- a/benchmarking/platforms/android/android_platform.py
+++ b/benchmarking/platforms/android/android_platform.py
@@ -93,6 +93,9 @@ class AndroidPlatform(PlatformBase):
                 )
         except Exception:
             getLogger().exception("Could not load thermal mapping")
+        # Silently set time if possible.
+        date_time_string = time.strftime("%m%d%H%M%Y.%S")
+        adb.shell(f'su 0 date "{date_time_string}"', silent=True)
 
     def getKind(self):
         return self.platform

--- a/benchmarking/tests/platforms/android/test_android_platform.py
+++ b/benchmarking/tests/platforms/android/test_android_platform.py
@@ -48,6 +48,7 @@ class AndroidPlatformTest(unittest.TestCase):
 
         self.adb.getprop = Mock(side_effect=mock_getprop)
         self.adb.logcat = Mock(return_value="success")
+        self.adb.shell = Mock()
         self.args = argparse.Namespace(
             android_dir=self.tempdir,
             device_name_mapping=None,


### PR DESCRIPTION
Summary: Time should be current on our devices for logging purposes.  Set the time on AndroidPlatform instantiation with call to date function.

Reviewed By: hl475

Differential Revision: D46312988

