### PR TITLE
Limit readline() 

### DIFF
--- a/ailab/benchmark/views.py
+++ b/ailab/benchmark/views.py
@@ -196,6 +196,6 @@ def visualize(request):
             "graph": rendered_graph,
             "table": rendered_table,
         }
-        return HttpResponse(json.dumps(response))
+        return HttpResponse(json.dumps(response), content_type="application/json")
     rendered = render_to_string("result_visualization.html", data, request)
     return HttpResponse(rendered)

--- a/benchmarking/frameworks/glow/glow.py
+++ b/benchmarking/frameworks/glow/glow.py
@@ -337,7 +337,7 @@ class GlowFramework(FrameworkBase):
         if not os.path.exists(traceFile):
             return
         with open(traceFile, "r") as fp:
-            line = fp.readline()
+            line = fp.readline(5_000_000)
             while line:
                 try:
                     parsed = json.loads(line.rstrip(", \n\t"))
@@ -366,4 +366,4 @@ class GlowFramework(FrameworkBase):
                     pass
                 except ValueError:
                     pass
-                line = fp.readline()
+                line = fp.readline(5_000_000)

--- a/benchmarking/utils/subprocess_with_logger.py
+++ b/benchmarking/utils/subprocess_with_logger.py
@@ -22,6 +22,7 @@ from threading import Timer
 
 from .custom_logger import getLogger
 from .utilities import getRunKilled, getRunTimeout, setRunStatus, setRunTimeout
+from security import safe_command
 
 
 def processRun(*args, **kwargs):
@@ -193,8 +194,7 @@ def _Popen(*args, **kwargs):
         if arg in kwargs:
             customArgs[arg] = kwargs[arg]
 
-    ps = subprocess.Popen(
-        *args,
+    ps = safe_command.run(subprocess.Popen, *args,
         bufsize=-1,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,

--- a/libraries/python/classification_compare.py
+++ b/libraries/python/classification_compare.py
@@ -55,15 +55,15 @@ class OutputCompare:
         num_entries = 0
         content_list = []
         with open(filename, "r") as f:
-            line = f.readline()
+            line = f.readline(5_000_000)
             dim_str = line
             while line != "":
                 assert dim_str == line, "The dimensions do not match"
                 num_entries = num_entries + 1
                 dims_list = [int(dim.strip()) for dim in line.strip().split(",")]
-                line = f.readline().strip()
+                line = f.readline(5_000_000).strip()
                 content_list.extend([float(entry.strip()) for entry in line.split(",")])
-                line = f.readline()
+                line = f.readline(5_000_000)
 
         dims_list.insert(0, num_entries)
         dims = np.asarray(dims_list)

--- a/libraries/python/coco/process_single_image_output.py
+++ b/libraries/python/coco/process_single_image_output.py
@@ -55,14 +55,14 @@ class ProcessSingleImageOutput:
     def getData(self, filename):
         result = []
         with open(filename, "r") as f:
-            line = f.readline()
+            line = f.readline(5_000_000)
             while line != "":
                 content_list = []
                 dims_list = [int(dim.strip()) for dim in line.strip().split(",")]
-                line = f.readline().strip()
+                line = f.readline(5_000_000).strip()
                 if len(line) > 0:
                     content_list = [float(entry.strip()) for entry in line.split(",")]
-                line = f.readline()
+                line = f.readline(5_000_000)
                 dims = np.asarray(dims_list)
                 content = np.asarray(content_list)
                 data = np.reshape(content, dims)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ requests>=2.21.0
 setuptools>=39.0.1
 six>=1.11.0
 tabulate>=0.8.3
+security==1.3.0


### PR DESCRIPTION
This codemod hardens all [`readline()`](https://docs.python.org/3/library/io.html#io.IOBase.readline) calls from file objects returned from an `open()` call, `StringIO` and `BytesIO` against denial of service attacks. A stream influenced by an attacker could keep providing bytes until the system runs out of memory, causing a crash.

Fixing it is straightforward by providing adding a size argument to any `readline()` calls.
The changes from this codemod look like this:

```diff
  file = open('some_file.txt')
- file.readline()
+ file.readline(5_000_000)
```

<details>
  <summary>More reading</summary>

  * [https://cwe.mitre.org/data/definitions/400.html](https://cwe.mitre.org/data/definitions/400.html)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/limit-readline](https://docs.pixee.ai/codemods/python/pixee_python_limit-readline)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2FFAI-PEP%7C65b9afcb6d7031cdda1761f5bd60065f31e90dad)

<!--{"type":"DRIP","codemod":"pixee:python/limit-readline"}-->