### PR TITLE
Replace usage of deprecated `distutils.(file|dir)_util`

### DIFF
--- a/benchmarking/benchmarks/benchmarks.py
+++ b/benchmarking/benchmarks/benchmarks.py
@@ -259,9 +259,9 @@ class BenchmarkCollector:
                         )
                         os.symlink(abs_name, destination_name)
             elif os.path.isdir(abs_name):
-                import distutils.dir_util
+                import shutil
 
-                distutils.dir_util.copy_tree(abs_name, destination_name)
+                shutil.copytree(abs_name, destination_name)
             else:
                 raise AssertionError(f"Path {abs_name} cannot be retrieved.")
                 return False


### PR DESCRIPTION
Summary:
`distutils` has been deprecated since Python 3.10, and [removed in Python 3.12](https://docs.python.org/3/whatsnew/3.12.html#distutils).

Existing usage will now raise the following error under Python 3.12+:

```
ModuleNotFoundError: No module named 'distutils'
```

This diff replaces `distutils` usage according to [PEP-632 migration advice](https://peps.python.org/pep-0632/#migration-advice).

---

I generated this diff by looking for all usages of `distutils.*copy_(tree|file)` and replaced them with `shutil.copy(tree|file)`. These should be close to drop-in replacements!

Differential Revision: D73804939


